### PR TITLE
LPS-57066 Fix NPE

### DIFF
--- a/modules/portal/portal-cxf-common/src/com/liferay/portal/cxf/common/configuration/CXFEndpointPublisherConfiguration.java
+++ b/modules/portal/portal-cxf-common/src/com/liferay/portal/cxf/common/configuration/CXFEndpointPublisherConfiguration.java
@@ -31,4 +31,10 @@ public interface CXFEndpointPublisherConfiguration {
 	@Meta.AD(name = "required.extensions", required = false)
 	public String[] extensions();
 
+	@Meta.AD(
+		deflt = "auth.verifier.PortalSessionAuthVerifier.urls.includes=*",
+		name = "portal.auth.configuration", required = false
+	)
+	public String[] portalAuthConfiguration();
+
 }

--- a/modules/portal/portal-soap-extender/src/com/liferay/portal/soap/extender/internal/JaxWsApiEnabler.java
+++ b/modules/portal/portal-soap-extender/src/com/liferay/portal/soap/extender/internal/JaxWsApiEnabler.java
@@ -82,7 +82,9 @@ public class JaxWsApiEnabler {
 
 	@Deactivate
 	protected void deactivate() {
-		_serviceRegistration.unregister();
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
 
 		_serviceTracker.close();
 	}


### PR DESCRIPTION
Hi Carlos

In the end I configured it again as previously - HTTP Filter per CXF servlet. 

I found several advantages:
1, It's very simple solution => works OOTB
2, I don't need to change AuthVerifier architecture -> no changes to core.
3, There is a configuration parameter `portalAuthConfiguration` using that it's possible to configure each AuthVerifier to match each endpoint URL, if needed.
4, When it's not specified then portal filters are not in place and the behavior is the normal one
5, I don't need to write custom JAX-RS filters and custom hooks into CXF for SOAP transport security

Please if you are fine with it, send it to Brian.

Next week I start my vacation.

Btw. I got a lot of headaches because of the `null` location in the example project: 
```
_configurationAdmin.createFactoryConfiguration(
			"com.liferay.portal.cxf.common.configuration." +
				"CXFEndpointPublisherConfiguration", null);
```

When I uninstall portal-cxf-common bundle then the configurations are bound to some nearest module and never re-registers back again. Seems any fictive location fixes the issue (in portal we use question mark):
```
_configurationAdmin.createFactoryConfiguration(
			"com.liferay.portal.cxf.common.configuration." +
				"CXFEndpointPublisherConfiguration", "?");
```

/cc @mikakoivisto