### PR TITLE
[TS] LPS-73622 ClassNotFoundException: com.liferay.portal.minifier.GoogleJavaScriptMinifier cannot be found when StripFilter set to false upon server startup

### DIFF
--- a/portal-impl/src/com/liferay/portal/minifier/MinifierUtil.java
+++ b/portal-impl/src/com/liferay/portal/minifier/MinifierUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InstanceFactory;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.util.PropsValues;
 
 import com.yahoo.platform.yui.compressor.CssCompressor;
@@ -48,6 +49,7 @@ public class MinifierUtil {
 	private static JavaScriptMinifier _getJavaScriptMinifier() {
 		try {
 			return (JavaScriptMinifier)InstanceFactory.newInstance(
+				PortalClassLoaderUtil.getClassLoader(),
 				PropsValues.MINIFIER_JAVASCRIPT_IMPL);
 		}
 		catch (Exception e) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73622
Caused by liferay@e4113a6841b879e74feb52f1a556e6a14cc873b4, [LPS-44366](https://issues.liferay.com/browse/LPS-44366)

Hi Carlos,

I'm forwarding this to you first as you were also working on LPS-44366 :-)

Can you please review this and forward to someone from the Core or Frontend Infrastructure team if you agree?

**Solution Notes**
As both of our current implementations of `com.liferay.portal.minifier.JavaScriptMinifier` reside in `portal-impl` and certain servlet filters can map to bundle-related resources also, we should not let `InstanceFactory.newInstance` to fall-back to the "contextClassLoader" of the current thread, so we decided to pass-in the portal's classloader explicitly.
 
Thanks!
Tibi

/cc @peterpetrekanics