### PR TITLE
oauth2-scopes-with-cxf-redirection-repackage-rebased-with-applicationscopes-wip

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationModel.java
@@ -280,6 +280,21 @@ public interface OAuth2ApplicationModel extends AuditedModel,
 	 */
 	public void setWebUrl(String webUrl);
 
+	/**
+	 * Returns the scopes of this o auth2 application.
+	 *
+	 * @return the scopes of this o auth2 application
+	 */
+	@AutoEscape
+	public String getScopes();
+
+	/**
+	 * Sets the scopes of this o auth2 application.
+	 *
+	 * @param scopes the scopes of this o auth2 application
+	 */
+	public void setScopes(String scopes);
+
 	@Override
 	public boolean isNew();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationSoap.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationSoap.java
@@ -46,6 +46,7 @@ public class OAuth2ApplicationSoap implements Serializable {
 		soapModel.setDescription(model.getDescription());
 		soapModel.setName(model.getName());
 		soapModel.setWebUrl(model.getWebUrl());
+		soapModel.setScopes(model.getScopes());
 
 		return soapModel;
 	}
@@ -205,6 +206,14 @@ public class OAuth2ApplicationSoap implements Serializable {
 		_webUrl = webUrl;
 	}
 
+	public String getScopes() {
+		return _scopes;
+	}
+
+	public void setScopes(String scopes) {
+		_scopes = scopes;
+	}
+
 	private long _oAuth2ApplicationId;
 	private long _companyId;
 	private long _userId;
@@ -218,4 +227,5 @@ public class OAuth2ApplicationSoap implements Serializable {
 	private String _description;
 	private String _name;
 	private String _webUrl;
+	private String _scopes;
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationWrapper.java
@@ -71,6 +71,7 @@ public class OAuth2ApplicationWrapper implements OAuth2Application,
 		attributes.put("description", getDescription());
 		attributes.put("name", getName());
 		attributes.put("webUrl", getWebUrl());
+		attributes.put("scopes", getScopes());
 
 		return attributes;
 	}
@@ -154,6 +155,12 @@ public class OAuth2ApplicationWrapper implements OAuth2Application,
 
 		if (webUrl != null) {
 			setWebUrl(webUrl);
+		}
+
+		String scopes = (String)attributes.get("scopes");
+
+		if (scopes != null) {
+			setScopes(scopes);
 		}
 	}
 
@@ -285,6 +292,16 @@ public class OAuth2ApplicationWrapper implements OAuth2Application,
 	@Override
 	public java.lang.String getRedirectUri() {
 		return _oAuth2Application.getRedirectUri();
+	}
+
+	/**
+	* Returns the scopes of this o auth2 application.
+	*
+	* @return the scopes of this o auth2 application
+	*/
+	@Override
+	public java.lang.String getScopes() {
+		return _oAuth2Application.getScopes();
 	}
 
 	/**
@@ -491,6 +508,16 @@ public class OAuth2ApplicationWrapper implements OAuth2Application,
 	@Override
 	public void setRedirectUri(java.lang.String redirectUri) {
 		_oAuth2Application.setRedirectUri(redirectUri);
+	}
+
+	/**
+	* Sets the scopes of this o auth2 application.
+	*
+	* @param scopes the scopes of this o auth2 application
+	*/
+	@Override
+	public void setScopes(java.lang.String scopes) {
+		_oAuth2Application.setScopes(scopes);
 	}
 
 	/**

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/LiferayOAuthDataProvider.java
@@ -16,9 +16,11 @@ package com.liferay.oauth2.provider.rest;
 
 import com.liferay.oauth2.provider.exception.NoSuchOAuth2ApplicationException;
 import com.liferay.oauth2.provider.exception.NoSuchOAuth2TokenException;
+import com.liferay.oauth2.provider.model.LiferayOAuth2Scope;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2RefreshToken;
 import com.liferay.oauth2.provider.model.OAuth2Token;
+import com.liferay.oauth2.provider.scopes.impl.model.LiferayOAuth2ScopeImpl;
 import com.liferay.oauth2.provider.scopes.liferay.api.ScopeFinderLocator;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2RefreshTokenLocalService;
@@ -47,10 +49,12 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component(service = LiferayOAuthDataProvider.class)
 public class LiferayOAuthDataProvider extends AbstractAuthorizationCodeDataProvider {
@@ -335,7 +339,10 @@ public class LiferayOAuthDataProvider extends AbstractAuthorizationCodeDataProvi
 	
 		client.setApplicationDescription(
 			oAuth2Application.getDescription());
-	
+
+		client.setRegisteredScopes(
+			OAuthUtils.parseScope(oAuth2Application.getScopes()));
+
 		client.setRedirectUris(
 			Collections.singletonList(oAuth2Application.getRedirectUri()));
 	

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/LiferayOAuthDataProvider.java
@@ -335,13 +335,6 @@ public class LiferayOAuthDataProvider extends AbstractAuthorizationCodeDataProvi
 	
 		client.setApplicationDescription(
 			oAuth2Application.getDescription());
-
-		/*
-		client.setRegisteredScopes();
-
-		get scopes from database
-
-		 */
 	
 		client.setRedirectUris(
 			Collections.singletonList(oAuth2Application.getRedirectUri()));

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/OAuth2AuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/OAuth2AuthVerifier.java
@@ -81,12 +81,7 @@ public class OAuth2AuthVerifier implements AuthVerifier {
 			
 			for (OAuthPermission scope : accessToken.getScopes()) {
 				ServiceAccessPolicyThreadLocal.addActiveServiceAccessPolicyName(
-					scope.getPermission());
-
-				/*
-				Do not prefix the permission, for the sake of transparency send what's granted,
-				this expects the scope.permissions to be initialized with real SAP name
-				 */
+					"OAUTH_" + scope.getPermission());
 
 			}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
@@ -26,7 +26,8 @@
 		<column name="description" type="String" />
 		<column name="name" type="String" />
 		<column name="webUrl" type="String" />
-		
+		<column name="scopes" type="String" />
+
 		<finder name="C_CI" return-type="OAuth2Application">
 			<finder-column name="companyId" />
 			<finder-column name="clientId" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
@@ -96,22 +96,7 @@
 		<reference entity="OAuth2Token" package-path="com.liferay.oauth2.provider" />
 	</entity>
 
-	<!--
-
-	Mapping between applications and scopes and later requested+approved tokens and scopes
-
-	<entity name="TokenScopes">
-		<column name="tokenId" type="" />
-		<column name="scopeId" type="" />
-	</entity>
-
-	<entity name="ApplicationScopes">
-		<column name="applicationId" type="" />
-		<column name="scopeId" type="" />
-	</entity>
-
-	-->
-	<entity name="OAuth2Scope" local-service="true" remote-service="false">
+	<entity name="OAuth2ScopeGrant" local-service="true" remote-service="false">
 		<!-- PK fields -->
 
 		<column name="applicationName" primary="true" type="String" />
@@ -119,6 +104,7 @@
 		<column name="bundleVersion" primary="true" type="String" />
 		<column name="companyId" type="long" primary="true" />
 		<column name="oAuth2ScopeName" primary="true" type="String" />
+		<column name="oAuth2TokenId" primary="true" type="String" />
 
 		<!-- Audit fields -->
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationCacheModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationCacheModel.java
@@ -65,7 +65,7 @@ public class OAuth2ApplicationCacheModel implements CacheModel<OAuth2Application
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(27);
+		StringBundler sb = new StringBundler(29);
 
 		sb.append("{oAuth2ApplicationId=");
 		sb.append(oAuth2ApplicationId);
@@ -93,6 +93,8 @@ public class OAuth2ApplicationCacheModel implements CacheModel<OAuth2Application
 		sb.append(name);
 		sb.append(", webUrl=");
 		sb.append(webUrl);
+		sb.append(", scopes=");
+		sb.append(scopes);
 		sb.append("}");
 
 		return sb.toString();
@@ -171,6 +173,13 @@ public class OAuth2ApplicationCacheModel implements CacheModel<OAuth2Application
 			oAuth2ApplicationImpl.setWebUrl(webUrl);
 		}
 
+		if (scopes == null) {
+			oAuth2ApplicationImpl.setScopes("");
+		}
+		else {
+			oAuth2ApplicationImpl.setScopes(scopes);
+		}
+
 		oAuth2ApplicationImpl.resetOriginalValues();
 
 		return oAuth2ApplicationImpl;
@@ -194,6 +203,7 @@ public class OAuth2ApplicationCacheModel implements CacheModel<OAuth2Application
 		description = objectInput.readUTF();
 		name = objectInput.readUTF();
 		webUrl = objectInput.readUTF();
+		scopes = objectInput.readUTF();
 	}
 
 	@Override
@@ -258,6 +268,13 @@ public class OAuth2ApplicationCacheModel implements CacheModel<OAuth2Application
 		else {
 			objectOutput.writeUTF(webUrl);
 		}
+
+		if (scopes == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(scopes);
+		}
 	}
 
 	public long oAuth2ApplicationId;
@@ -273,4 +290,5 @@ public class OAuth2ApplicationCacheModel implements CacheModel<OAuth2Application
 	public String description;
 	public String name;
 	public String webUrl;
+	public String scopes;
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
@@ -76,7 +76,8 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 			{ "clientConfidential", Types.BOOLEAN },
 			{ "description", Types.VARCHAR },
 			{ "name", Types.VARCHAR },
-			{ "webUrl", Types.VARCHAR }
+			{ "webUrl", Types.VARCHAR },
+			{ "scopes", Types.VARCHAR }
 		};
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
 
@@ -94,9 +95,10 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 		TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("webUrl", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("scopes", Types.VARCHAR);
 	}
 
-	public static final String TABLE_SQL_CREATE = "create table OAuth2Application (oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,clientId VARCHAR(75) null,clientSecret VARCHAR(75) null,redirectUri VARCHAR(75) null,clientConfidential BOOLEAN,description VARCHAR(75) null,name VARCHAR(75) null,webUrl VARCHAR(75) null)";
+	public static final String TABLE_SQL_CREATE = "create table OAuth2Application (oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,clientId VARCHAR(75) null,clientSecret VARCHAR(75) null,redirectUri VARCHAR(75) null,clientConfidential BOOLEAN,description VARCHAR(75) null,name VARCHAR(75) null,webUrl VARCHAR(75) null,scopes VARCHAR(75) null)";
 	public static final String TABLE_SQL_DROP = "drop table OAuth2Application";
 	public static final String ORDER_BY_JPQL = " ORDER BY oAuth2Application.oAuth2ApplicationId ASC";
 	public static final String ORDER_BY_SQL = " ORDER BY OAuth2Application.oAuth2ApplicationId ASC";
@@ -168,6 +170,7 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 		attributes.put("description", getDescription());
 		attributes.put("name", getName());
 		attributes.put("webUrl", getWebUrl());
+		attributes.put("scopes", getScopes());
 
 		attributes.put("entityCacheEnabled", isEntityCacheEnabled());
 		attributes.put("finderCacheEnabled", isFinderCacheEnabled());
@@ -254,6 +257,12 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 
 		if (webUrl != null) {
 			setWebUrl(webUrl);
+		}
+
+		String scopes = (String)attributes.get("scopes");
+
+		if (scopes != null) {
+			setScopes(scopes);
 		}
 	}
 
@@ -466,6 +475,21 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 		_webUrl = webUrl;
 	}
 
+	@Override
+	public String getScopes() {
+		if (_scopes == null) {
+			return "";
+		}
+		else {
+			return _scopes;
+		}
+	}
+
+	@Override
+	public void setScopes(String scopes) {
+		_scopes = scopes;
+	}
+
 	public long getColumnBitmask() {
 		return _columnBitmask;
 	}
@@ -510,6 +534,7 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 		oAuth2ApplicationImpl.setDescription(getDescription());
 		oAuth2ApplicationImpl.setName(getName());
 		oAuth2ApplicationImpl.setWebUrl(getWebUrl());
+		oAuth2ApplicationImpl.setScopes(getScopes());
 
 		oAuth2ApplicationImpl.resetOriginalValues();
 
@@ -669,12 +694,20 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 			oAuth2ApplicationCacheModel.webUrl = null;
 		}
 
+		oAuth2ApplicationCacheModel.scopes = getScopes();
+
+		String scopes = oAuth2ApplicationCacheModel.scopes;
+
+		if ((scopes != null) && (scopes.length() == 0)) {
+			oAuth2ApplicationCacheModel.scopes = null;
+		}
+
 		return oAuth2ApplicationCacheModel;
 	}
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(27);
+		StringBundler sb = new StringBundler(29);
 
 		sb.append("{oAuth2ApplicationId=");
 		sb.append(getOAuth2ApplicationId());
@@ -702,6 +735,8 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 		sb.append(getName());
 		sb.append(", webUrl=");
 		sb.append(getWebUrl());
+		sb.append(", scopes=");
+		sb.append(getScopes());
 		sb.append("}");
 
 		return sb.toString();
@@ -709,7 +744,7 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 
 	@Override
 	public String toXmlString() {
-		StringBundler sb = new StringBundler(43);
+		StringBundler sb = new StringBundler(46);
 
 		sb.append("<model><model-name>");
 		sb.append("com.liferay.oauth2.provider.model.OAuth2Application");
@@ -767,6 +802,10 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 			"<column><column-name>webUrl</column-name><column-value><![CDATA[");
 		sb.append(getWebUrl());
 		sb.append("]]></column-value></column>");
+		sb.append(
+			"<column><column-name>scopes</column-name><column-value><![CDATA[");
+		sb.append(getScopes());
+		sb.append("]]></column-value></column>");
 
 		sb.append("</model>");
 
@@ -794,6 +833,7 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 	private String _description;
 	private String _name;
 	private String _webUrl;
+	private String _scopes;
 	private long _columnBitmask;
 	private OAuth2Application _escapedModel;
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
@@ -98,7 +98,7 @@ public class OAuth2ApplicationModelImpl extends BaseModelImpl<OAuth2Application>
 		TABLE_COLUMNS_MAP.put("scopes", Types.VARCHAR);
 	}
 
-	public static final String TABLE_SQL_CREATE = "create table OAuth2Application (oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,clientId VARCHAR(75) null,clientSecret VARCHAR(75) null,redirectUri VARCHAR(75) null,clientConfidential BOOLEAN,description VARCHAR(75) null,name VARCHAR(75) null,webUrl VARCHAR(75) null,scopes VARCHAR(75) null)";
+	public static final String TABLE_SQL_CREATE = "create table OAuth2Application (oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,clientId VARCHAR(75) null,clientSecret VARCHAR(75) null,redirectUri VARCHAR(75) null,clientConfidential BOOLEAN,description VARCHAR(75) null,name VARCHAR(75) null,webUrl VARCHAR(75) null,scopes STRING null)";
 	public static final String TABLE_SQL_DROP = "drop table OAuth2Application";
 	public static final String ORDER_BY_JPQL = " ORDER BY oAuth2Application.oAuth2ApplicationId ASC";
 	public static final String ORDER_BY_SQL = " ORDER BY OAuth2Application.oAuth2ApplicationId ASC";

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ApplicationPersistenceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ApplicationPersistenceImpl.java
@@ -691,6 +691,7 @@ public class OAuth2ApplicationPersistenceImpl extends BasePersistenceImpl<OAuth2
 		oAuth2ApplicationImpl.setDescription(oAuth2Application.getDescription());
 		oAuth2ApplicationImpl.setName(oAuth2Application.getName());
 		oAuth2ApplicationImpl.setWebUrl(oAuth2Application.getWebUrl());
+		oAuth2ApplicationImpl.setScopes(oAuth2Application.getScopes());
 
 		return oAuth2ApplicationImpl;
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/module-hbm.xml
@@ -22,6 +22,7 @@
 		<property name="description" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property name="webUrl" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property name="scopes" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 	</class>
 	<class name="com.liferay.oauth2.provider.model.impl.OAuth2RefreshTokenImpl" table="OAuth2RefreshToken">
 		<id access="com.liferay.portal.dao.orm.hibernate.CamelCasePropertyAccessor" name="oAuth2RefreshTokenId" type="java.lang.String">

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -15,7 +15,9 @@
 		<field name="description" type="String" />
 		<field name="name" type="String" />
 		<field name="webUrl" type="String" />
-		<field name="scopes" type="String" />
+		<field name="scopes" type="String">
+			<hint-collection name="TEXTAREA" />
+		</field>
 	</model>
 	<model name="com.liferay.oauth2.provider.model.OAuth2RefreshToken">
 		<field name="oAuth2RefreshTokenId" type="String" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -15,6 +15,7 @@
 		<field name="description" type="String" />
 		<field name="name" type="String" />
 		<field name="webUrl" type="String" />
+		<field name="scopes" type="String" />
 	</model>
 	<model name="com.liferay.oauth2.provider.model.OAuth2RefreshToken">
 		<field name="oAuth2RefreshTokenId" type="String" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
@@ -12,7 +12,7 @@ create table OAuth2Application (
 	description VARCHAR(75) null,
 	name VARCHAR(75) null,
 	webUrl VARCHAR(75) null,
-	scopes VARCHAR(75) null
+	scopes STRING null
 );
 
 create table OAuth2RefreshToken (

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
@@ -11,7 +11,8 @@ create table OAuth2Application (
 	clientConfidential BOOLEAN,
 	description VARCHAR(75) null,
 	name VARCHAR(75) null,
-	webUrl VARCHAR(75) null
+	webUrl VARCHAR(75) null,
+	scopes VARCHAR(75) null
 );
 
 create table OAuth2RefreshToken (

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=OAuthTwo
-    build.number=1
-    build.date=1514371672501
+    build.number=2
+    build.date=1514371672502

--- a/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
@@ -1,3 +1,6 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay", name: "com.liferay.application.list.api", version: "2.0.0"

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/LiferayOAuth2ScopesGrantPortlet.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/LiferayOAuth2ScopesGrantPortlet.java
@@ -77,16 +77,6 @@ public class LiferayOAuth2ScopesGrantPortlet extends MVCPortlet {
 		printWriter.append(
 			"<input type=\"hidden\" name=\"scope\" value=\"");
 		printWriter.append(ParamUtil.get(httpServletRequest, "scope", ""));
-
-		/*
-			show scopes from scope finder, but filtered against available scopes that are assigned to application
-
-			example: application requests everything, oauth2 admin selected blogs.everything for this app
-				=> show blogs.everything description
-
-			In this version we approve all scopes requested, don't further sub-select
-		*/
-
 		printWriter.append("\">");
 		printWriter.append(
 			"<input type=\"hidden\" name=\"session_authenticity_token\" " +

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/OAuth2AdminPortlet.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/OAuth2AdminPortlet.java
@@ -15,21 +15,37 @@
 package com.liferay.oauth2.provider.web;
 
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.scopes.liferay.api.ScopeFinderLocator;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceActionMapping;
+import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringPool;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.Portlet;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
 
+import com.liferay.portal.kernel.util.WebKeys;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Stian Sigvartsen

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/constants/OAuth2AdminWebKeys.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/constants/OAuth2AdminWebKeys.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.constants;
+
+/**
+ * @author Stian Sigvartsen
+ */
+public class OAuth2AdminWebKeys {
+
+	public static final String SCOPES = "scopes";
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/portlet/action/AssignScopesMVCActionCommand.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/portlet/action/AssignScopesMVCActionCommand.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.portlet.action;
+
+import com.liferay.oauth2.provider.model.LiferayOAuth2Scope;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.scopes.liferay.api.ScopeFinderLocator;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalServiceUtil;
+import com.liferay.oauth2.provider.web.OAuth2AdminPortletKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.WebKeys;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.liferay.oauth2.provider.web.internal.constants.OAuth2AdminWebKeys.SCOPES;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + OAuth2AdminPortletKeys.OAUTH2_ADMIN,
+		"mvc.command.name=/admin/assign_scopes"
+	}
+)
+public class AssignScopesMVCActionCommand implements MVCActionCommand {
+
+	@Override
+	public boolean processAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws PortletException {
+
+		StringBundler scopes = new StringBundler();
+		for (String parameterName : actionRequest.getParameterMap().keySet()) {
+			if (parameterName.startsWith("scope_") &&
+				ParamUtil.getBoolean(actionRequest, parameterName)) {
+
+				if (scopes.length() > 0) {
+					scopes.append(" ");
+				}
+
+				scopes.append(parameterName.substring("scope_".length()));
+			}
+		}
+
+		long oAuth2ApplicationId = ParamUtil.getLong(
+			actionRequest, "oAuth2ApplicationId");
+
+		try {
+			OAuth2Application oAuth2Application =
+				_oAuth2ApplicationLocalService.getOAuth2Application(
+					oAuth2ApplicationId);
+
+			oAuth2Application.setScopes(scopes.toString());
+
+			_oAuth2ApplicationLocalService.updateOAuth2Application(
+				oAuth2Application);
+		}
+		catch (PortalException e) {
+			if (_log.isDebugEnabled()) {
+				_log.warn(
+					"Unable to load OAuth2Application with id " +
+					oAuth2ApplicationId);
+			}
+		}
+
+		return true;
+	}
+
+
+	@Reference
+	private ScopeFinderLocator _scopeFinderLocator;
+
+	@Reference
+	OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	private Log _log = LogFactoryUtil.getLog(AssignScopesMVCActionCommand.class);
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/portlet/action/AssignScopesMVCRenderCommand.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/portlet/action/AssignScopesMVCRenderCommand.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.portlet.action;
+
+import com.liferay.oauth2.provider.model.LiferayOAuth2Scope;
+import com.liferay.oauth2.provider.scopes.liferay.api.ScopeFinderLocator;
+import com.liferay.oauth2.provider.web.OAuth2AdminPortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.WebKeys;
+import org.osgi.framework.Bundle;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.liferay.oauth2.provider.web.internal.constants.OAuth2AdminWebKeys.SCOPES;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + OAuth2AdminPortletKeys.OAUTH2_ADMIN,
+		"mvc.command.name=/admin/assign_scopes"
+	}
+)
+public class AssignScopesMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Collection<LiferayOAuth2Scope> scopes = _scopeFinderLocator.listScopes(
+			themeDisplay.getCompany());
+
+		Map<String, List<LiferayOAuth2Scope>> applicationScopes = new HashMap<>();
+
+		for (LiferayOAuth2Scope scope : scopes) {
+			List<LiferayOAuth2Scope> applicationScopeList =
+				applicationScopes.computeIfAbsent(
+					scope.getApplicationName(), key -> new ArrayList<>());
+
+			applicationScopeList.add(new SerializableLiferayOAuth2Scope(scope));
+		}
+
+		renderRequest.setAttribute(SCOPES, applicationScopes);
+
+		return "/admin/assign_scopes.jsp";
+	}
+
+	@Reference
+	private ScopeFinderLocator _scopeFinderLocator;
+}
+
+class SerializableLiferayOAuth2Scope implements LiferayOAuth2Scope {
+
+	public SerializableLiferayOAuth2Scope(
+		LiferayOAuth2Scope liferayOAuth2Scope) {
+		_liferayOAuth2Scope = liferayOAuth2Scope;
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return _liferayOAuth2Scope.getBundle();
+	}
+
+	@Override
+	public String getApplicationName() {
+		return _liferayOAuth2Scope.getApplicationName();
+	}
+
+	@Override
+	public String getScope() {
+		return _liferayOAuth2Scope.getScope();
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(5);
+
+		sb.append(getBundle().getSymbolicName());
+		sb.append("/");
+		sb.append(getApplicationName());
+		sb.append("/");
+		sb.append(getScope());
+
+		return sb.toString();
+	}
+
+	private LiferayOAuth2Scope _liferayOAuth2Scope;
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
@@ -1,0 +1,81 @@
+<%@ page import="com.liferay.oauth2.provider.model.LiferayOAuth2Scope" %>
+<%@ page import="static com.liferay.oauth2.provider.web.internal.constants.OAuth2AdminWebKeys.SCOPES" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %>
+<%@ page import="java.util.Arrays" %><%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="../init.jsp" %>
+
+<%
+	String redirect = ParamUtil.getString(request, "redirect");
+
+	long oAuth2ApplicationId = ParamUtil.getLong(request, "oAuth2ApplicationId", -1);
+
+	OAuth2Application oAuth2Application = null;
+
+	if (oAuth2ApplicationId > -1) {
+		oAuth2Application = OAuth2ApplicationLocalServiceUtil.getOAuth2Application(oAuth2ApplicationId);
+	}
+
+	portletDisplay.setShowBackIcon(true);
+
+	portletDisplay.setURLBack(redirect);
+
+	renderResponse.setTitle(LanguageUtil.get(request, "assign-scopes"));
+
+	Map<String, List<LiferayOAuth2Scope>> scopes = (Map<String, List<LiferayOAuth2Scope>>) request.getAttribute(SCOPES);
+
+	List<String> assignedScopes = Arrays.asList(oAuth2Application.getScopes().split(" "));
+%>
+
+<div class="container-fluid-1280">
+	<portlet:actionURL name="/admin/assign_scopes" var="updateScopesURL" />
+	<aui:form action="<%= updateScopesURL %>" name="fm">
+
+		<aui:fieldset-group markupView="lexicon">
+			<aui:input type="hidden" name="oAuth2ApplicationId" value='<%= oAuth2ApplicationId %>' />
+
+			<%
+				for (Map.Entry<String, List<LiferayOAuth2Scope>> applicationScopes : scopes.entrySet()) {
+					String applicationName = applicationScopes.getKey();
+
+			%>
+			<aui:fieldset label="<%= HtmlUtil.escape(applicationName) %>" localizeLabel="false">
+				<%
+					for (LiferayOAuth2Scope scope : applicationScopes.getValue()) {
+						String externalIdentifier = scope.toString();
+						boolean checked = assignedScopes.contains(externalIdentifier);
+				%>
+					<div>
+						<aui:input checked="<%= checked %>" label="<%= HtmlUtil.escape(scope.getScope()) %>" localizeLabel="false" name="<%= "scope_" + externalIdentifier %>" type="checkbox" />
+					</div>
+				<%
+					}
+				%>
+			</aui:fieldset>
+			<%
+				}
+			%>
+		</aui:fieldset-group>
+
+		<aui:button-row>
+			<aui:button cssClass="btn-lg" type="submit" />
+			<aui:button cssClass="btn-lg" onClick="<%= portletDisplay.getURLBack() %>" type="cancel" />
+		</aui:button-row>
+	</aui:form>
+</div>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/oauth2application_actions.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/oauth2application_actions.jsp
@@ -17,12 +17,12 @@
 <%@ include file="../init.jsp" %>
 
 <%
-String mvcPath = ParamUtil.getString(request, "mvcPath");
 
-ResultRow row = (ResultRow)request
-				.getAttribute("SEARCH_CONTAINER_RESULT_ROW");
+ResultRow row = (ResultRow)request.getAttribute("SEARCH_CONTAINER_RESULT_ROW");
 
 OAuth2Application oauth2application = (OAuth2Application)row.getObject();
+
+String oAuth2ApplicationId = String.valueOf(oauth2application.getOAuth2ApplicationId());
 %>
 
 <liferay-ui:icon-menu
@@ -33,9 +33,7 @@ OAuth2Application oauth2application = (OAuth2Application)row.getObject();
 	showWhenSingleIcon="<%= true %>"
 >
 	<portlet:renderURL var="editURL">
-		<portlet:param name="oAuth2ApplicationId"
-			value="<%= String.valueOf(oauth2application.getOAuth2ApplicationId()) %>"
-		/>
+		<portlet:param name="oAuth2ApplicationId" value="<%= oAuth2ApplicationId %>" />
 
 		<portlet:param name="mvcPath"
 			value="/admin/edit_oauth2application.jsp"
@@ -50,10 +48,16 @@ OAuth2Application oauth2application = (OAuth2Application)row.getObject();
 		url="<%= editURL.toString() %>"
 	/>
 
+	<portlet:renderURL var="assignScopesURL">
+		<portlet:param name="mvcRenderCommandName" value="/admin/assign_scopes" />
+		<portlet:param name="oAuth2ApplicationId" value="<%= oAuth2ApplicationId %>" />
+		<portlet:param name="redirect" value="<%= currentURL %>" />
+	</portlet:renderURL>
+
+	<liferay-ui:icon message="assign-scopes" url="<%= assignScopesURL.toString() %>" />
+
 	<portlet:actionURL name="deleteOAuth2Application" var="deleteURL">
-		<portlet:param name="oAuth2ApplicationId"
-			value="<%= String.valueOf(oauth2application.getOAuth2ApplicationId()) %>"
-		/>
+		<portlet:param name="oAuth2ApplicationId" value="<%= oAuth2ApplicationId %>" />
 	</portlet:actionURL>
 
 	<liferay-ui:icon-delete message="delete" url="<%= deleteURL.toString() %>" />


### PR DESCRIPTION
1. Added portlet screen to assign scopes to an app
2. Save the scopes into OAuth2Application ( with custom serialization) 
3. Load the scopes into CXF
4.When approved, save scopes as OAuth2ScopesGrant (with custom deserialization)

Custom serialization - deserialization is due to missing LiferayOAuth2Scope.externalId . I use LiferayOAuth2Scope.scope as human-readable scope name.
