### PR TITLE
ScopedServiceTrackerMap Long keys

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-scopes-liferay-api/src/main/java/com/liferay/oauth2/provider/scopes/liferay/api/ScopedServiceTrackerMap.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scopes-liferay-api/src/main/java/com/liferay/oauth2/provider/scopes/liferay/api/ScopedServiceTrackerMap.java
@@ -61,7 +61,7 @@ public class ScopedServiceTrackerMap<T> {
 				bundleContext, clazz,
 				"(&(companyId=*)(" + property + "=*))",
 				(serviceReference, emitter) -> {
-					ServiceReferenceMapper<String, T>
+					ServiceReferenceMapper<Long, T>
 						companyMapper = new PropertyServiceReferenceMapper<>(
 							"companyId");
 					ServiceReferenceMapper<String, T>
@@ -73,15 +73,14 @@ public class ScopedServiceTrackerMap<T> {
 						key1 -> nameMapper.map(
 							serviceReference,
 							key2 -> emitter.emit(
-								String.join("-", key1, key2))));
+								String.join("-", Long.toString(key1), key2))));
 				},
 				new ServiceTrackerMapListenerImpl<>());
 	}
 
 	public T getService(long companyId, String key) {
-		String companyIdString = Long.toString(companyId);
 		List<T> services = _servicesByCompanyAndKey.getService(
-			String.join("-", companyIdString, key));
+			String.join("-", Long.toString(companyId), key));
 
 		if (services != null && !services.isEmpty()) {
 			return services.get(0);
@@ -93,7 +92,7 @@ public class ScopedServiceTrackerMap<T> {
 			return services.get(0);
 		}
 
-		services = _servicesByCompany.getService(companyIdString);
+		services = _servicesByCompany.getService(companyId);
 
 		if (services != null && !services.isEmpty()) {
 			return services.get(0);
@@ -108,16 +107,16 @@ public class ScopedServiceTrackerMap<T> {
 		_servicesByKey.close();
 	}
 
-	private ServiceTrackerMap<String, List<T>> _servicesByCompany;
+	private ServiceTrackerMap<Long, List<T>> _servicesByCompany;
 	private ServiceTrackerMap<String, List<T>> _servicesByCompanyAndKey;
 	private ServiceTrackerMap<String, List<T>> _servicesByKey;
 
-	private class ServiceTrackerMapListenerImpl<T>
-		implements ServiceTrackerMapListener<String, T, List<T>> {
+	private class ServiceTrackerMapListenerImpl<I, T>
+		implements ServiceTrackerMapListener<I, T, List<T>> {
 		@Override
 		public void keyEmitted(
-			ServiceTrackerMap<String, List<T>> serviceTrackerMap,
-			String key,
+			ServiceTrackerMap<I, List<T>> serviceTrackerMap,
+			I key,
 			T service, List<T> content) {
 
 			_onChange.run();
@@ -125,8 +124,8 @@ public class ScopedServiceTrackerMap<T> {
 
 		@Override
 		public void keyRemoved(
-			ServiceTrackerMap<String, List<T>> serviceTrackerMap,
-			String key,
+			ServiceTrackerMap<I, List<T>> serviceTrackerMap,
+			I key,
 			T service, List<T> content) {
 
 			_onChange.run();


### PR DESCRIPTION
Hi Carlos. I would appreciate your guidance on resolving this exception. You mentioned surrounding the emit call with a try/catch...

```
ERROR [Refresh Thread: Equinox Container: f0b6e01d-d117-0018-1f49-b3d6c8305e76][com_liferay_oauth2_provider_scopes_impl:97] [com.liferay.oauth2.provider.scopes.impl.ScopeRegistry(3786)] The activate method has thrown an exception
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Long
	at com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceMapper.map(PropertyServiceReferenceMapper.java:43)
	at com.liferay.oauth2.provider.scopes.liferay.api.ScopedServiceTrackerMap.lambda$new$3(ScopedServiceTrackerMap.java:71)
	at com.liferay.osgi.service.tracker.collections.internal.map.ServiceTrackerMapImpl$ServiceReferenceServiceTrackerCustomizer.addingService(ServiceTrackerMapImpl.java:264)
	at com.liferay.osgi.service.tracker.collections.internal.map.ServiceTrackerMapImpl$ServiceReferenceServiceTrackerCustomizer.addingService(ServiceTrackerMapImpl.java:251)
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:941)
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:1)
	at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)
	at org.osgi.util.tracker.AbstractTracked.trackInitial(AbstractTracked.java:183)
	at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:318)
	at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:261)
	at com.liferay.osgi.service.tracker.collections.internal.map.ServiceTrackerMapImpl.open(ServiceTrackerMapImpl.java:94)
	at com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory.openMultiValueMap(ServiceTrackerMapFactory.java:199)
	at com.liferay.oauth2.provider.scopes.liferay.api.ScopedServiceTrackerMap.<init>(ScopedServiceTrackerMap.java:60)
	at com.liferay.oauth2.provider.scopes.impl.ScopeRegistry.activate(ScopeRegistry.java:199)
```