### PR TITLE
OAuth2 scope-impl SF

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/bnd.bnd
@@ -1,3 +1,3 @@
-Bundle-Name: Liferay OAuth2 Provider Scopes Implementation
+Bundle-Name: Liferay OAuth2 Provider Scope Implementation
 Bundle-SymbolicName: com.liferay.oauth2.provider.scope.impl
 Bundle-Version: 1.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/DefaultScopeDescriptorLocator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/DefaultScopeDescriptorLocator.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/DefaultScopeDescriptorLocator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/DefaultScopeDescriptorLocator.java
@@ -25,6 +25,9 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 @Component
 public class DefaultScopeDescriptorLocator implements ScopeDescriptorLocator {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/DefaultScopeDescriptorLocator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/DefaultScopeDescriptorLocator.java
@@ -60,12 +60,12 @@ public class DefaultScopeDescriptorLocator implements ScopeDescriptorLocator {
 		_scopeDescriptorsByCompany.close();
 	}
 
+	@Reference(target = "(default=true)")
+	private ScopeDescriptor _defaultScopeDescriptor;
+
 	private ServiceTrackerMap<String, ScopeDescriptor>
 		_scopeDescriptorsByApplicationName;
 	private ServiceTrackerMap<String, ScopeDescriptor>
 		_scopeDescriptorsByCompany;
-
-	@Reference(target = "(default=true)")
-	ScopeDescriptor _defaultScopeDescriptor;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ScopeRegistry.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ScopeRegistry.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ScopeRegistry.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ScopeRegistry.java
@@ -55,6 +55,9 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 @Component(immediate = true, service = ScopeLocator.class)
 public class ScopeRegistry implements ScopeLocator {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ThreadLocalServiceScopeChecker.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ThreadLocalServiceScopeChecker.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ThreadLocalServiceScopeChecker.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ThreadLocalServiceScopeChecker.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
@@ -34,14 +35,6 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = {ScopeChecker.class, ScopeContext.class})
 public class ThreadLocalServiceScopeChecker
 	implements ScopeChecker, ScopeContext {
-
-	ThreadLocal<Long> _companyIdThreadLocal = ThreadLocal.withInitial(() -> 0L);
-	ThreadLocal<String> _bundleSymbolicName = ThreadLocal.withInitial(
-		() -> StringPool.BLANK);
-	ThreadLocal<String> _applicationName = ThreadLocal.withInitial(
-		() -> StringPool.BLANK);
-	ThreadLocal<String> _accessToken = ThreadLocal.withInitial(
-		() -> StringPool.BLANK);
 
 	@Override
 	public boolean checkAllScopes(String... scopes) {
@@ -111,8 +104,9 @@ public class ThreadLocalServiceScopeChecker
 				_applicationName.get(), _bundleSymbolicName.get(),
 				_companyIdThreadLocal.get(), _accessToken.get());
 
-		return oAuth2ScopeGrants.stream().anyMatch(
-			o -> scope.equals(o.getOAuth2ScopeName()));
+		Stream<OAuth2ScopeGrant> stream = oAuth2ScopeGrants.stream();
+
+		return stream.anyMatch(o -> scope.equals(o.getOAuth2ScopeName()));
 	}
 
 	@Override
@@ -143,7 +137,16 @@ public class ThreadLocalServiceScopeChecker
 		_companyIdThreadLocal.set(companyId);
 	}
 
+	private final ThreadLocal<String> _accessToken = ThreadLocal.withInitial(
+		() -> StringPool.BLANK);
+	private final ThreadLocal<String> _applicationName =
+		ThreadLocal.withInitial(() -> StringPool.BLANK);
+	private final ThreadLocal<String> _bundleSymbolicName =
+		ThreadLocal.withInitial(() -> StringPool.BLANK);
+	private final ThreadLocal<Long> _companyIdThreadLocal =
+		ThreadLocal.withInitial(() -> 0L);
+
 	@Reference
-	OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
+	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ThreadLocalServiceScopeChecker.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/ThreadLocalServiceScopeChecker.java
@@ -28,6 +28,9 @@ import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 @Component(service = {ScopeChecker.class, ScopeContext.class})
 public class ThreadLocalServiceScopeChecker
 	implements ScopeChecker, ScopeContext {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/CollectionScopeFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/CollectionScopeFinder.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/CollectionScopeFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/CollectionScopeFinder.java
@@ -18,7 +18,10 @@ import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 
 import java.util.Collection;
 
-class CollectionScopeFinder implements ScopeFinder {
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class CollectionScopeFinder implements ScopeFinder {
 
 	public CollectionScopeFinder(Collection<String> scopes) {
 		_scopes = scopes;

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/LiferayOAuth2OSGiFeature.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/LiferayOAuth2OSGiFeature.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/LiferayOAuth2OSGiFeature.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/LiferayOAuth2OSGiFeature.java
@@ -69,6 +69,9 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.util.tracker.ServiceTracker;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 @Component(immediate = true, property = {"liferay.extension=OAuth2"})
 @Provider
 public class LiferayOAuth2OSGiFeature implements Feature {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeAnnotationFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeAnnotationFinder.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeAnnotationFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeAnnotationFinder.java
@@ -18,8 +18,8 @@ import com.liferay.oauth2.provider.scope.RequiresScope;
 
 import java.lang.reflect.Method;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,7 +29,11 @@ import org.apache.cxf.jaxrs.model.MethodDispatcher;
 import org.apache.cxf.jaxrs.model.OperationResourceInfo;
 import org.apache.cxf.jaxrs.utils.ResourceUtils;
 
-class ScopeAnnotationFinder {
+/**
+ * @author Carlos Sierra Andrés
+ * @review
+ */
+public class ScopeAnnotationFinder {
 
 	public static Collection<String> find(Class<?> clazz, Bus bus) {
 		ClassResourceInfo classResourceInfo =
@@ -38,12 +42,12 @@ class ScopeAnnotationFinder {
 
 		Set<String> scopes = new HashSet<>();
 
-		doFind(new HashSet<>(), scopes, true, classResourceInfo);
+		_find(new HashSet<>(), scopes, true, classResourceInfo);
 
 		return scopes;
 	}
 
-	private static void doFind(
+	private static void _find(
 		Set<ClassResourceInfo> visited, Set<String> accum, boolean recurse,
 		ClassResourceInfo classResourceInfo) {
 
@@ -55,7 +59,7 @@ class ScopeAnnotationFinder {
 			RequiresScope.class);
 
 		if (declaredAnnotation != null) {
-			accum.addAll(Arrays.asList(declaredAnnotation.value()));
+			Collections.addAll(accum, declaredAnnotation.value());
 		}
 
 		MethodDispatcher methodDispatcher =
@@ -65,15 +69,15 @@ class ScopeAnnotationFinder {
 			methodDispatcher.getOperationResourceInfos();
 
 		for (OperationResourceInfo operationResourceInfo :
-			operationResourceInfos) {
+				operationResourceInfos) {
 
-			doFind(visited, accum, recurse, operationResourceInfo);
+			_find(visited, accum, recurse, operationResourceInfo);
 		}
 
 		visited.remove(classResourceInfo);
 	}
 
-	private static void doFind(
+	private static void _find(
 		Set<ClassResourceInfo> visited, Set<String> accum, boolean recurse,
 		OperationResourceInfo operationResourceInfo) {
 
@@ -83,22 +87,21 @@ class ScopeAnnotationFinder {
 			annotatedMethod.getDeclaredAnnotation(RequiresScope.class);
 
 		if (declaredAnnotation != null) {
-			accum.addAll(Arrays.asList(declaredAnnotation.value()));
+			Collections.addAll(accum, declaredAnnotation.value());
 		}
 
 		if (operationResourceInfo.isSubResourceLocator()) {
 			ClassResourceInfo classResourceInfo =
 				operationResourceInfo.getClassResourceInfo();
 
-			Class<?> returnType =
-				operationResourceInfo.getAnnotatedMethod().getReturnType();
+			Class<?> returnType = annotatedMethod.getReturnType();
 
-			ClassResourceInfo subResource = classResourceInfo.getSubResource(
+			ClassResourceInfo subresource = classResourceInfo.getSubResource(
 				returnType, returnType);
 
-			if (subResource != null) {
+			if (subresource != null) {
 				if (recurse) {
-					doFind(visited, accum, false, subResource);
+					_find(visited, accum, false, subresource);
 				}
 			}
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeContextContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeContextContainerRequestFilter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeContextContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeContextContainerRequestFilter.java
@@ -26,7 +26,11 @@ import javax.ws.rs.core.Context;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
-class ScopeContextContainerRequestFilter implements ContainerRequestFilter {
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class ScopeContextContainerRequestFilter
+	implements ContainerRequestFilter {
 
 	public ScopeContextContainerRequestFilter(ScopeContext scopeContext) {
 		_scopeContext = scopeContext;

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeContextContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/ScopeContextContainerRequestFilter.java
@@ -40,14 +40,16 @@ public class ScopeContextContainerRequestFilter
 	public void filter(ContainerRequestContext requestContext)
 		throws IOException {
 
-		Bundle bundle = FrameworkUtil.getBundle(_application.getClass());
+		Class<? extends Application> clazz = _application.getClass();
+
+		Bundle bundle = FrameworkUtil.getBundle(clazz);
 
 		if (bundle == null) {
 			return;
 		}
 
 		_scopeContext.setBundle(bundle);
-		_scopeContext.setApplicationName(_application.getClass().getName());
+		_scopeContext.setApplicationName(clazz.getName());
 	}
 
 	@Context

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/TestFeature.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/TestFeature.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/TestFeature.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/feature/TestFeature.java
@@ -22,6 +22,9 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 @Component(
 	property = {"osgi.jaxrs.extension=true", "osgi.jaxrs.name=Test.Feature"},
 	scope = ServiceScope.PROTOTYPE

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/CompanyRetrieverContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/CompanyRetrieverContainerRequestFilter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/CompanyRetrieverContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/CompanyRetrieverContainerRequestFilter.java
@@ -26,6 +26,9 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Context;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 public class CompanyRetrieverContainerRequestFilter
 	implements ContainerRequestFilter {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/RunnableExecutorContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/RunnableExecutorContainerRequestFilter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/RunnableExecutorContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/RunnableExecutorContainerRequestFilter.java
@@ -19,6 +19,9 @@ import java.io.IOException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 public class RunnableExecutorContainerRequestFilter
 	implements ContainerRequestFilter {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/RunnableExecutorContainerResponseFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/RunnableExecutorContainerResponseFilter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/RunnableExecutorContainerResponseFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/RunnableExecutorContainerResponseFilter.java
@@ -20,6 +20,9 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 public class RunnableExecutorContainerResponseFilter
 	implements ContainerResponseFilter {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/ScopedRequestScopeChecker.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/ScopedRequestScopeChecker.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/ScopedRequestScopeChecker.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/ScopedRequestScopeChecker.java
@@ -32,6 +32,9 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 public class ScopedRequestScopeChecker implements ContainerRequestFilter {
 
 	public ScopedRequestScopeChecker(

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/ScopedRequestScopeChecker.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/jaxrs/ScopedRequestScopeChecker.java
@@ -75,17 +75,17 @@ public class ScopedRequestScopeChecker implements ContainerRequestFilter {
 		}
 	}
 
+	@Context
+	private Application _application;
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
+
+	@Context
+	private ResourceInfo _resourceInfo;
+
 	private final ScopeChecker _scopeChecker;
 	private final ScopedServiceTrackerMap<RequestScopeCheckerFilter>
 		_scopedServiceTrackerMap;
-
-	@Context
-	Application _application;
-
-	@Context
-	HttpServletRequest _httpServletRequest;
-
-	@Context
-	ResourceInfo _resourceInfo;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/model/LiferayOAuth2ScopeImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/model/LiferayOAuth2ScopeImpl.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/model/LiferayOAuth2ScopeImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/model/LiferayOAuth2ScopeImpl.java
@@ -20,6 +20,9 @@ import java.util.Objects;
 
 import org.osgi.framework.Bundle;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 
 	public LiferayOAuth2ScopeImpl(

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/model/LiferayOAuth2ScopeImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/model/LiferayOAuth2ScopeImpl.java
@@ -39,7 +39,7 @@ public class LiferayOAuth2ScopeImpl implements LiferayOAuth2Scope {
 			return true;
 		}
 
-		if (o == null || getClass() != o.getClass()) {
+		if ((o == null) || (getClass() != o.getClass())) {
 			return false;
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/prefixhandler/BundleNamespacePrefixHandlerFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/prefixhandler/BundleNamespacePrefixHandlerFactory.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/prefixhandler/BundleNamespacePrefixHandlerFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/prefixhandler/BundleNamespacePrefixHandlerFactory.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.StringReader;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -44,11 +43,9 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  * @author Stian Sigvartsen
  */
 @Component(
-	immediate = true,
-	configurationPid = "com.liferay.oauth2.provider.configuration." +
-		"BundleNamespacePrefixHandlerFactory",
-	property = {"separator=" + StringPool.SLASH},
-	configurationPolicy = ConfigurationPolicy.REQUIRE
+	configurationPid = "com.liferay.oauth2.provider.configuration.BundleNamespacePrefixHandlerFactory",
+	configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true,
+	property = {"separator=" + StringPool.SLASH}
 )
 public class BundleNamespacePrefixHandlerFactory
 	implements PrefixHandlerFactory {
@@ -100,21 +97,20 @@ public class BundleNamespacePrefixHandlerFactory
 				StringPool.SPACE, "\n");
 
 			Properties modifiers = new Properties();
+
 			try {
 				modifiers.load(new StringReader(propertiesFormat));
 			}
 			catch (IOException ioe) {
-	}
+			}
 
-			parts.add(
-				GetterUtil.getString(
-					modifiers.getProperty("default"), StringPool.BLANK));
+			parts.add(GetterUtil.getString(modifiers.getProperty("default")));
 		}
 
 		PrefixHandler prefixHandler = create(
 			parts.toArray(_EMPTY_STRING_ARRAY));
 
-		return (target) -> {
+		return target -> {
 			if (_excludedScope.contains(target)) {
 				return target;
 			}
@@ -131,7 +127,7 @@ public class BundleNamespacePrefixHandlerFactory
 			sb.append(_separator);
 		}
 
-		return (target) -> sb.toString() + target;
+		return target -> sb.toString() + target;
 	}
 
 	@Activate
@@ -151,9 +147,7 @@ public class BundleNamespacePrefixHandlerFactory
 			serviceProperties = (String[])servicePropertyObject;
 		}
 		else if (servicePropertyObject != null) {
-			serviceProperties = Collections.singletonList(
-					servicePropertyObject.toString()).toArray(
-						_EMPTY_STRING_ARRAY);
+			serviceProperties = new String[] {servicePropertyObject.toString()};
 		}
 		else {
 			serviceProperties = _EMPTY_STRING_ARRAY;
@@ -182,8 +176,8 @@ public class BundleNamespacePrefixHandlerFactory
 
 		_bundleContext = bundleContext;
 
-		_excludedScope.addAll(
-			Arrays.asList(excludedScopeProperty.split(StringPool.COMMA)));
+		Collections.addAll(
+			_excludedScope, excludedScopeProperty.split(StringPool.COMMA));
 
 		_excludedScope.removeIf(Validator::isBlank);
 
@@ -195,7 +189,7 @@ public class BundleNamespacePrefixHandlerFactory
 		_includeBundleSymbolicName = includeBundleSymbolicName;
 	}
 
-	private String[] _EMPTY_STRING_ARRAY = new String[0];
+	private static final String[] _EMPTY_STRING_ARRAY = new String[0];
 
 	private BundleContext _bundleContext;
 	private List<String> _excludedScope = new ArrayList<>();

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/prefixhandler/BundleNamespacePrefixHandlerFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/prefixhandler/BundleNamespacePrefixHandlerFactory.java
@@ -39,6 +39,10 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
+/**
+ * @author Carlos Sierra Andrés
+ * @author Stian Sigvartsen
+ */
 @Component(
 	immediate = true,
 	configurationPid = "com.liferay.oauth2.provider.configuration." +

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedescriptor/DefaultScopeDescriptor.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedescriptor/DefaultScopeDescriptor.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedescriptor/DefaultScopeDescriptor.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedescriptor/DefaultScopeDescriptor.java
@@ -16,6 +16,7 @@ package com.liferay.oauth2.provider.scope.impl.scopedescriptor;
 
 import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -42,7 +43,7 @@ public class DefaultScopeDescriptor implements ScopeDescriptor {
 			return scope;
 		}
 
-		return resourceBundle.getString(scope);
+		return ResourceBundleUtil.getString(resourceBundle, scope);
 	}
 
 	@Reference(

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedescriptor/DefaultScopeDescriptor.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedescriptor/DefaultScopeDescriptor.java
@@ -25,6 +25,9 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 @Component(immediate = true, property = "default=true")
 public class DefaultScopeDescriptor implements ScopeDescriptor {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedservicetrackermap/ScopedServiceTrackerMapFactoryImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedservicetrackermap/ScopedServiceTrackerMapFactoryImpl.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedservicetrackermap/ScopedServiceTrackerMapFactoryImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedservicetrackermap/ScopedServiceTrackerMapFactoryImpl.java
@@ -28,6 +28,9 @@ import java.util.function.Supplier;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Component;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 @Component
 public class ScopedServiceTrackerMapFactoryImpl
 	implements ScopedServiceTrackerMapFactory {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedservicetrackermap/ScopedServiceTrackerMapFactoryImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopedservicetrackermap/ScopedServiceTrackerMapFactoryImpl.java
@@ -71,8 +71,7 @@ public class ScopedServiceTrackerMapFactoryImpl
 					"(&(companyId=*)(" + property + "=*))",
 					(serviceReference, emitter) -> {
 						ServiceReferenceMapper<String, T> companyMapper =
-								new PropertyServiceReferenceMapper<>(
-									"companyId");
+							new PropertyServiceReferenceMapper<>("companyId");
 						ServiceReferenceMapper<String, T> nameMapper =
 							new PropertyServiceReferenceMapper<>(property);
 
@@ -96,22 +95,23 @@ public class ScopedServiceTrackerMapFactoryImpl
 		@Override
 		public T getService(long companyId, String key) {
 			String companyIdString = Long.toString(companyId);
+
 			List<T> services = _servicesByCompanyAndKey.getService(
 				String.join("-", companyIdString, key));
 
-			if (services != null && !services.isEmpty()) {
+			if ((services != null) && !services.isEmpty()) {
 				return services.get(0);
 			}
 
 			services = _servicesByKey.getService(key);
 
-			if (services != null && !services.isEmpty()) {
+			if ((services != null) && !services.isEmpty()) {
 				return services.get(0);
 			}
 
 			services = _servicesByCompany.getService(companyIdString);
 
-			if (services != null && !services.isEmpty()) {
+			if ((services != null) && !services.isEmpty()) {
 				return services.get(0);
 			}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopemapper/ConfigurableScopeMapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopemapper/ConfigurableScopeMapper.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopemapper/ConfigurableScopeMapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopemapper/ConfigurableScopeMapper.java
@@ -17,7 +17,7 @@ package com.liferay.oauth2.provider.scope.impl.scopemapper;
 import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.portal.kernel.util.GetterUtil;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -31,9 +31,8 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  * @author Stian Sigvartsen
  */
 @Component(
-	immediate = true,
 	configurationPid = "com.liferay.oauth2.provider.configuration.ConfigurableScopeMapper",
-	configurationPolicy = ConfigurationPolicy.REQUIRE
+	configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true
 )
 public class ConfigurableScopeMapper implements ScopeMapper {
 
@@ -69,7 +68,7 @@ public class ConfigurableScopeMapper implements ScopeMapper {
 	protected void activate(Map<String, Object> properties) {
 		Object mappings = properties.get("mapping");
 
-		if (mappings == null || !(mappings instanceof String[])) {
+		if ((mappings == null) || !(mappings instanceof String[])) {
 			return;
 		}
 
@@ -93,7 +92,7 @@ public class ConfigurableScopeMapper implements ScopeMapper {
 				Set<String> mappingOutput = _map.computeIfAbsent(
 					mappingInput, __ -> new HashSet<>());
 
-				mappingOutput.addAll(Arrays.asList(mappingParts[1].split(",")));
+				Collections.addAll(mappingOutput, mappingParts[1].split(","));
 			}
 		}
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopemapper/ConfigurableScopeMapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopemapper/ConfigurableScopeMapper.java
@@ -27,6 +27,9 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
+/**
+ * @author Stian Sigvartsen
+ */
 @Component(
 	immediate = true,
 	configurationPid = "com.liferay.oauth2.provider.configuration.ConfigurableScopeMapper",

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopematcher/ChunkScopeMatcherFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopematcher/ChunkScopeMatcherFactory.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopematcher/ChunkScopeMatcherFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/impl/scopematcher/ChunkScopeMatcherFactory.java
@@ -25,6 +25,9 @@ import java.util.Map;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 @Component(
 	configurationPid = "com.liferay.oauth2.provider.impl.scope.ChunkScopeMatcherFactory",
 	property = {"default=true", "separator=" + StringPool.PERIOD, "type=chunks"}

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultBundleNamespacePrefixHandlerFactoryBeanDeclaration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultBundleNamespacePrefixHandlerFactoryBeanDeclaration.java
@@ -12,9 +12,9 @@
  * details.
  */
 
-package com.liferay.oauth2.provider.internal.configuration;
+package com.liferay.oauth2.provider.scope.internal.configuration;
 
-import com.liferay.oauth2.provider.configuration.OAuth2Configuration;
+import com.liferay.oauth2.provider.configuration.DefaultBundleNamespacePrefixHandlerFactoryRegistratorConfiguration;
 import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
 
 import org.osgi.service.component.annotations.Component;
@@ -23,11 +23,12 @@ import org.osgi.service.component.annotations.Component;
  * @author Stian Sigvartsen
  */
 @Component(immediate = true, service = ConfigurationBeanDeclaration.class)
-public class OAuth2BeanDeclaration implements ConfigurationBeanDeclaration {
+public class DefaultBundleNamespacePrefixHandlerFactoryBeanDeclaration
+	implements ConfigurationBeanDeclaration {
 
 	@Override
 	public Class<?> getConfigurationBeanClass() {
-		return OAuth2Configuration.class;
+		return DefaultBundleNamespacePrefixHandlerFactoryRegistratorConfiguration.class;
 	}
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultBundleNamespacePrefixHandlerFactoryRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultBundleNamespacePrefixHandlerFactoryRegistrator.java
@@ -1,4 +1,4 @@
-package com.liferay.oauth2.provider.internal.configuration;
+package com.liferay.oauth2.provider.scope.internal.configuration;
 
 import com.liferay.oauth2.provider.configuration.DefaultBundleNamespacePrefixHandlerFactoryRegistratorConfiguration;
 import com.liferay.oauth2.provider.scope.impl.prefixhandler.BundleNamespacePrefixHandlerFactory;

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultBundleNamespacePrefixHandlerFactoryRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultBundleNamespacePrefixHandlerFactoryRegistrator.java
@@ -19,9 +19,9 @@ import org.osgi.service.component.annotations.Deactivate;
  * @author Stian Sigvartsen
  */
 @Component(
-	immediate = true,
-	configurationPid = "com.liferay.oauth2.provider.configuration."
-			+ "DefaultBundleNamespacePrefixHandlerFactoryRegistratorConfiguration"
+	configurationPid = "com.liferay.oauth2.provider.configuration." +
+		"DefaultBundleNamespacePrefixHandlerFactoryRegistratorConfiguration",
+	immediate = true
 )
 public class DefaultBundleNamespacePrefixHandlerFactoryRegistrator {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultBundleNamespacePrefixHandlerFactoryRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultBundleNamespacePrefixHandlerFactoryRegistrator.java
@@ -15,6 +15,9 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 
+/**
+ * @author Stian Sigvartsen
+ */
 @Component(
 	immediate = true,
 	configurationPid = "com.liferay.oauth2.provider.configuration."

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultConfigurableScopeMapperRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultConfigurableScopeMapperRegistrator.java
@@ -19,8 +19,8 @@ import org.osgi.service.component.annotations.Deactivate;
  * @author Stian Sigvartsen
  */
 @Component(
-	immediate = true,
-	configurationPid = "com.liferay.oauth2.provider.configuration.DefaultConfigurableScopeMapperRegistratorConfiguration"
+	configurationPid = "com.liferay.oauth2.provider.configuration.DefaultConfigurableScopeMapperRegistratorConfiguration",
+	immediate = true
 )
 public class DefaultConfigurableScopeMapperRegistrator {
 
@@ -31,11 +31,13 @@ public class DefaultConfigurableScopeMapperRegistrator {
 		boolean enabled = GetterUtil.getBoolean(
 			properties.get("enabled"), true);
 
+		Class<DefaultConfigurableScopeMapperRegistratorConfiguration> clazz =
+			DefaultConfigurableScopeMapperRegistratorConfiguration.class;
+
 		if (enabled) {
-			DefaultConfigurableScopeMapperRegistratorConfiguration configuration =
-				ConfigurableUtil.createConfigurable(
-					DefaultConfigurableScopeMapperRegistratorConfiguration.class,
-					properties);
+			DefaultConfigurableScopeMapperRegistratorConfiguration
+				configuration = ConfigurableUtil.createConfigurable(
+					clazz, properties);
 
 			Hashtable<String, Object> scopeMapperProperties = new Hashtable<>();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultConfigurableScopeMapperRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultConfigurableScopeMapperRegistrator.java
@@ -1,4 +1,4 @@
-package com.liferay.oauth2.provider.internal.configuration;
+package com.liferay.oauth2.provider.scope.internal.configuration;
 
 import com.liferay.oauth2.provider.configuration.DefaultConfigurableScopeMapperRegistratorConfiguration;
 import com.liferay.oauth2.provider.scope.impl.scopemapper.ConfigurableScopeMapper;

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultConfigurableScopeMapperRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultConfigurableScopeMapperRegistrator.java
@@ -15,6 +15,9 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 
+/**
+ * @author Stian Sigvartsen
+ */
 @Component(
 	immediate = true,
 	configurationPid = "com.liferay.oauth2.provider.configuration.DefaultConfigurableScopeMapperRegistratorConfiguration"

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultScopeMapperBeanDeclaration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/DefaultScopeMapperBeanDeclaration.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.oauth2.provider.internal.configuration;
+package com.liferay.oauth2.provider.scope.internal.configuration;
 
 import com.liferay.oauth2.provider.configuration.DefaultConfigurableScopeMapperRegistratorConfiguration;
 import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/OAuth2BeanDeclaration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/OAuth2BeanDeclaration.java
@@ -12,9 +12,9 @@
  * details.
  */
 
-package com.liferay.oauth2.provider.internal.configuration;
+package com.liferay.oauth2.provider.scope.internal.configuration;
 
-import com.liferay.oauth2.provider.configuration.DefaultBundleNamespacePrefixHandlerFactoryRegistratorConfiguration;
+import com.liferay.oauth2.provider.configuration.OAuth2Configuration;
 import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
 
 import org.osgi.service.component.annotations.Component;
@@ -23,12 +23,11 @@ import org.osgi.service.component.annotations.Component;
  * @author Stian Sigvartsen
  */
 @Component(immediate = true, service = ConfigurationBeanDeclaration.class)
-public class DefaultBundleNamespacePrefixHandlerFactoryBeanDeclaration
-	implements ConfigurationBeanDeclaration {
+public class OAuth2BeanDeclaration implements ConfigurationBeanDeclaration {
 
 	@Override
 	public Class<?> getConfigurationBeanClass() {
-		return DefaultBundleNamespacePrefixHandlerFactoryRegistratorConfiguration.class;
+		return OAuth2Configuration.class;
 	}
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ChunkScopeMatcherFactoryTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ChunkScopeMatcherFactoryTest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ChunkScopeMatcherFactoryTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ChunkScopeMatcherFactoryTest.java
@@ -14,13 +14,11 @@
 
 package com.liferay.oauth2.provider.scope.impl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.liferay.oauth2.provider.scope.impl.scopematcher.ChunkScopeMatcherFactory;
 import com.liferay.oauth2.provider.scope.spi.scope.matcher.ScopeMatcher;
 import com.liferay.oauth2.provider.scope.spi.scope.matcher.ScopeMatcherFactory;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -36,8 +34,8 @@ public class ChunkScopeMatcherFactoryTest {
 		ScopeMatcher scopeMatcher = chunkScopeMatcherFactory.create(
 			"everything.readonly");
 
-		assertTrue(scopeMatcher.match("everything.readonly"));
-		assertFalse(scopeMatcher.match("everything"));
+		Assert.assertTrue(scopeMatcher.match("everything.readonly"));
+		Assert.assertFalse(scopeMatcher.match("everything"));
 	}
 
 	@Test
@@ -48,8 +46,8 @@ public class ChunkScopeMatcherFactoryTest {
 		ScopeMatcher scopeMatcher = chunkScopeMatcherFactory.create(
 			"everything");
 
-		assertTrue(scopeMatcher.match("everything.readonly"));
-		assertTrue(scopeMatcher.match("everything"));
+		Assert.assertTrue(scopeMatcher.match("everything.readonly"));
+		Assert.assertTrue(scopeMatcher.match("everything"));
 	}
 
 	@Test
@@ -60,8 +58,8 @@ public class ChunkScopeMatcherFactoryTest {
 		ScopeMatcher scopeMatcher = chunkScopeMatcherFactory.create(
 			"everything");
 
-		assertFalse(scopeMatcher.match("everything2.readonly"));
-		assertFalse(scopeMatcher.match("everything2"));
+		Assert.assertFalse(scopeMatcher.match("everything2.readonly"));
+		Assert.assertFalse(scopeMatcher.match("everything2"));
 	}
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ChunkScopeMatcherFactoryTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ChunkScopeMatcherFactoryTest.java
@@ -23,6 +23,9 @@ import com.liferay.oauth2.provider.scope.spi.scope.matcher.ScopeMatcherFactory;
 
 import org.junit.Test;
 
+/**
+ * @author Carlos Sierra Andrés
+ */
 public class ChunkScopeMatcherFactoryTest {
 
 	@Test

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ScopeRegistryTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ScopeRegistryTest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ScopeRegistryTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/ScopeRegistryTest.java
@@ -58,6 +58,9 @@ import org.osgi.framework.ServiceReference;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+/**
+ * @author Stian Sigvartsen
+ */
 @RunWith(PowerMockRunner.class)
 public class ScopeRegistryTest extends PowerMockito {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/TestScopedServiceTrackerMap.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/TestScopedServiceTrackerMap.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- * <p>
+ *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- * <p>
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/TestScopedServiceTrackerMap.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/TestScopedServiceTrackerMap.java
@@ -17,6 +17,9 @@ package com.liferay.oauth2.provider.scope.impl;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @author Stian Sigvartsen
+ */
 public class TestScopedServiceTrackerMap<T> {
 
 	public TestScopedServiceTrackerMap(T defaultService) {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/TestScopedServiceTrackerMap.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/impl/TestScopedServiceTrackerMap.java
@@ -32,6 +32,7 @@ public class TestScopedServiceTrackerMap<T> {
 
 	public T getService(long companyId, String key) {
 		String companyIdString = Long.toString(companyId);
+
 		T services = _servicesByCompanyAndKey.get(
 			String.join("-", companyIdString, key));
 
@@ -56,6 +57,7 @@ public class TestScopedServiceTrackerMap<T> {
 
 	public void setService(long companyId, String key, T service) {
 		String companyIdString = Long.toString(companyId);
+
 		String companyIdKeyString = String.join("-", companyIdString, key);
 
 		_servicesByCompanyAndKey.put(companyIdKeyString, service);
@@ -68,7 +70,7 @@ public class TestScopedServiceTrackerMap<T> {
 	}
 
 	public void setService(Long companyId, String key, T service) {
-		if (companyId == null && key != null) {
+		if ((companyId == null) && (key != null)) {
 			setService(key, service);
 		}
 		else if (key == null) {


### PR DESCRIPTION
Most SF issues are now resolved, with the exception of:

- BundleNamespacePrefixHandlerFactory and associated classes. SF will not accept such long names.

- ScopeRegistry. Hard to find the correct formatting for builder patterns with Lambda functions. Especially empty functions

- ScopedRequestScopeChecker. SF complains about swallowing an exception. I'm unsure how we should change it

/cc @topolik