### PR TITLE
OAUTH2-160 Sensible defaults - opinions?

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/build.gradle
@@ -1,3 +1,5 @@
+task deployConfigs(type: Copy)
+
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
@@ -25,4 +27,17 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile group: "junit", name: "junit", version: "4.12"
+}
+
+deploy {
+	finalizedBy deployConfigs
+}
+
+deployConfigs {
+	ext {
+		autoClean = false
+	}
+
+	from "configs"
+	into new File(liferay.liferayHome, "osgi/configs")
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/configs/com.liferay.oauth2.provider.scope.internal.configuration.ConfigurableScopeMapperConfiguration-default.config
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/configs/com.liferay.oauth2.provider.scope.internal.configuration.ConfigurableScopeMapperConfiguration-default.config
@@ -1,0 +1,3 @@
+passthrough="false"
+osgi.jaxrs.name="Default"
+mapping=["GET,HEAD,OPTIONS\=everything.read","PUT,POST,PATCH,DELETE\=everything,everything.write"]

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/BundlePrefixHandlerFactoryConfiguration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/BundlePrefixHandlerFactoryConfiguration.java
@@ -36,14 +36,14 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface BundlePrefixHandlerFactoryConfiguration {
 
 	@Meta.AD(
-		deflt = "Default", description = "osgi-jaxrs-name-description",
+		description = "osgi-jaxrs-name-description",
 		id = OAuth2ProviderScopeConstants.OSGI_JAXRS_NAME,
-		name = "osgi-jaxrs-name", required = false
+		name = "osgi-jaxrs-name", required = true
 	)
 	public String osgiJAXRSName();
 
 	@Meta.AD(
-		deflt = "true",
+		deflt = "false",
 		description = "include-bundle-symbolic-name-description",
 		id = "include.bundle.symbolic.name",
 		name = "include-bundle-symbolic-name", required = false
@@ -51,13 +51,12 @@ public interface BundlePrefixHandlerFactoryConfiguration {
 	public boolean includeBundleSymbolicName();
 
 	@Meta.AD(
-		deflt = "", description = "excluded-scopes-description",
-		id = "excluded.scopes", name = "excluded-scopes", required = false
+		description = "excluded-scopes-description", id = "excluded.scopes",
+		name = "excluded-scopes", required = false
 	)
 	public String[] excludedScopes();
 
 	@Meta.AD(
-		deflt = OAuth2ProviderScopeConstants.OSGI_JAXRS_NAME,
 		description = "service-properties-description",
 		id = "service.properties", name = "service-properties", required = false
 	)

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/BundlePrefixHandlerFactoryConfiguration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/BundlePrefixHandlerFactoryConfiguration.java
@@ -51,8 +51,8 @@ public interface BundlePrefixHandlerFactoryConfiguration {
 	public boolean includeBundleSymbolicName();
 
 	@Meta.AD(
-		description = "excluded-scopes-description", id = "excluded.scopes",
-		name = "excluded-scopes", required = false
+		deflt = "", description = "excluded-scopes-description",
+		id = "excluded.scopes", name = "excluded-scopes", required = false
 	)
 	public String[] excludedScopes();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/ConfigurableScopeMapperConfiguration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/ConfigurableScopeMapperConfiguration.java
@@ -35,14 +35,13 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface ConfigurableScopeMapperConfiguration {
 
 	@Meta.AD(
-		deflt = "Default", description = "osgi-jaxrs-name-description",
+		description = "osgi-jaxrs-name-description",
 		id = OAuth2ProviderScopeConstants.OSGI_JAXRS_NAME,
-		name = "osgi-jaxrs-name", required = false
+		name = "osgi-jaxrs-name", required = true
 	)
 	public String osgiJAXRSName();
 
 	@Meta.AD(
-		deflt = "GET\\,HEAD\\,OPTIONS=everything.readonly,PUT\\,POST\\,PATCH\\,DELETE=everything\\,everything.writeonly",
 		description = "mapping-description", id = "mapping", name = "mapping",
 		required = false
 	)

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/ConfigurableScopeMapperConfiguration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/configuration/ConfigurableScopeMapperConfiguration.java
@@ -42,8 +42,8 @@ public interface ConfigurableScopeMapperConfiguration {
 	public String osgiJAXRSName();
 
 	@Meta.AD(
-		description = "mapping-description", id = "mapping", name = "mapping",
-		required = false
+		deflt = "", description = "mapping-description", id = "mapping",
+		name = "mapping", required = false
 	)
 	public String[] mappings();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/spi/prefix/handler/PrefixHandlerFactoryImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/spi/prefix/handler/PrefixHandlerFactoryImpl.java
@@ -52,8 +52,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  */
 @Component(
 	configurationPid = "com.liferay.oauth2.provider.scope.internal.configuration.BundlePrefixHandlerFactoryConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL,
-	property = "default=true"
+	configurationPolicy = ConfigurationPolicy.REQUIRE
 )
 public class PrefixHandlerFactoryImpl implements PrefixHandlerFactory {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/spi/scope/mapper/ScopeMapperImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/spi/scope/mapper/ScopeMapperImpl.java
@@ -37,8 +37,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  */
 @Component(
 	configurationPid = "com.liferay.oauth2.provider.scope.internal.configuration.ConfigurableScopeMapperConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL,
-	property = "default=true"
+	configurationPolicy = ConfigurationPolicy.REQUIRE
 )
 public class ScopeMapperImpl implements ScopeMapper {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/resources/content/Language.properties
@@ -20,4 +20,4 @@ passthrough=Passthrough
 passthrough-description=When selected, all keys will be also added as values into the result without any mapping.
 separator-description=Set the string used as the parts delimiter.
 service-properties=Service Properties
-service-properties-description=Set the other bundle service properties that can be added into prefix. Order of items matters.
+service-properties-description=Set the other bundle service properties that can be added into prefix. For example "osgi.jaxrs.name". Order of items matters.

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/main/java/com/liferay/oauth2/provider/test/internal/TestPreviewURLApplication.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/main/java/com/liferay/oauth2/provider/test/internal/TestPreviewURLApplication.java
@@ -14,6 +14,8 @@
 
 package com.liferay.oauth2.provider.test.internal;
 
+import com.liferay.oauth2.provider.scope.RequiresNoScope;
+
 import java.util.Collections;
 import java.util.Set;
 
@@ -30,6 +32,7 @@ public class TestPreviewURLApplication extends Application {
 	}
 
 	@GET
+	@RequiresNoScope()
 	public String getPreviewURL() {
 		return _previewURL;
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpPrefixApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpPrefixApplicationClientTest.java
@@ -114,6 +114,12 @@ public class AnnotationsAndHttpPrefixApplicationClientTest
 
 			scopeMapperProperties.put(
 				"osgi.jaxrs.name", TestApplication.class.getName());
+			scopeMapperProperties.put(
+				"mapping",
+				new String[] {
+					"GET,HEAD,OPTIONS=everything.read",
+					"PUT,POST,PATCH,DELETE=everything,everything.write"
+				});
 
 			Dictionary<String, Object> bundlePrefixProperties =
 				new HashMapDictionary<>();

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/HttpMethodApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/HttpMethodApplicationClientTest.java
@@ -95,6 +95,23 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 
 			properties.put("oauth2.test.application", true);
 
+			Dictionary<String, Object> scopeMapperProperties =
+				new HashMapDictionary<>();
+
+			scopeMapperProperties.put(
+				"osgi.jaxrs.name", TestApplication.class.getName());
+			scopeMapperProperties.put(
+				"mapping",
+				new String[] {
+					"GET,HEAD,OPTIONS=everything.read",
+					"PUT,POST,PATCH,DELETE=everything,everything.write"
+				});
+
+			createFactoryConfiguration(
+				"com.liferay.oauth2.provider.scope.internal.configuration." +
+					"ConfigurableScopeMapperConfiguration",
+				scopeMapperProperties);
+
 			createOAuth2Application(
 				defaultCompanyId, user, "oauthTestApplicationBefore",
 				Arrays.asList("GET", "POST"));

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2WebServerServletTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2WebServerServletTest.java
@@ -135,6 +135,7 @@ public class OAuth2WebServerServletTest extends BaseClientTestCase {
 
 			properties.put(
 				"osgi.jaxrs.name", TestPreviewURLApplication.class.getName());
+			properties.put("oauth2.scopechecker.type", "annotations");
 
 			registerJaxRsApplication(
 				new TestPreviewURLApplication(previewURL), "preview-url",
@@ -143,7 +144,8 @@ public class OAuth2WebServerServletTest extends BaseClientTestCase {
 			createOAuth2Application(
 				defaultCompanyId, user, "oauthTestApplication",
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
-				Arrays.asList(new String[] {"GET", "documents_download"}));
+				Arrays.asList(
+					new String[] {"everything.read.documents.download"}));
 		}
 
 	}


### PR DESCRIPTION
I have come up with these changes to achieve what we have discussed over time, hopefully:

1. Scope aliases should automatically grow in scope if more JAX-RS modules are deployed. i.e. no prefix handler by default.
2. We want to map HTTP verbs to the global aliases "everything", "everything.read", "everything.write". However this only makes sense for the "Default" configuration instance. Because if you are not happy with it, your application is is using different scope names. Hence it makes sense to move it into a deployed .config file.
3. ScopeLocatorImpl provides hard coded passthrough impls when there is no ScopeMapper / PrefixHandlerFactory. Consequently we don't need these services always, so set to ConfigurationPolicy.REQUIRE.

I am working on fixing integration tests broken by these changes.

/cc @topolik 