### PR TITLE
LPS-83974 Strengthened tests for ServiceTrackerMap

### DIFF
--- a/modules/core/osgi-service-tracker-collections/src/main/java/com/liferay/osgi/service/tracker/collections/internal/map/MultiValueServiceTrackerBucketFactory.java
+++ b/modules/core/osgi-service-tracker-collections/src/main/java/com/liferay/osgi/service/tracker/collections/internal/map/MultiValueServiceTrackerBucketFactory.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.osgi.framework.ServiceReference;
 
@@ -79,6 +77,9 @@ public class MultiValueServiceTrackerBucketFactory<SR, TS>
 
 			_serviceReferenceServiceTuples.add(serviceReferenceServiceTuple);
 
+			_serviceReferenceServiceTuples.sort(
+				_serviceReferenceServiceTupleComparator);
+
 			rebuild();
 		}
 
@@ -96,15 +97,15 @@ public class MultiValueServiceTrackerBucketFactory<SR, TS>
 		}
 
 		private ListServiceTrackerBucket() {
-			ServiceReferenceServiceTupleComparator<SR>
-				serviceReferenceServiceTupleComparator =
-					new ServiceReferenceServiceTupleComparator<>(_comparator);
+			_serviceReferenceServiceTupleComparator =
+				new ServiceReferenceServiceTupleComparator<>(_comparator);
 
-			_serviceReferenceServiceTuples = new TreeSet<>(
-				serviceReferenceServiceTupleComparator);
+			_serviceReferenceServiceTuples = new ArrayList<>();
 		}
 
-		private final Set<ServiceReferenceServiceTuple<SR, TS>>
+		private final ServiceReferenceServiceTupleComparator<SR>
+			_serviceReferenceServiceTupleComparator;
+		private final List<ServiceReferenceServiceTuple<SR, TS>>
 			_serviceReferenceServiceTuples;
 		private List<TS> _services = new ArrayList<>();
 

--- a/modules/core/osgi-service-tracker-collections/src/main/java/com/liferay/osgi/service/tracker/collections/internal/map/SingleValueServiceTrackerBucketFactory.java
+++ b/modules/core/osgi-service-tracker-collections/src/main/java/com/liferay/osgi/service/tracker/collections/internal/map/SingleValueServiceTrackerBucketFactory.java
@@ -19,9 +19,10 @@ import com.liferay.osgi.service.tracker.collections.internal.ServiceReferenceSer
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerBucket;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerBucketFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.PriorityQueue;
+import java.util.List;
 
 import org.osgi.framework.ServiceReference;
 
@@ -53,12 +54,10 @@ public class SingleValueServiceTrackerBucketFactory<SR, TS>
 		public SingleBucket() {
 			_service = null;
 
-			ServiceReferenceServiceTupleComparator<SR>
-				serviceReferenceServiceTupleComparator =
-					new ServiceReferenceServiceTupleComparator<>(_comparator);
+			_serviceReferenceServiceTupleComparator =
+				new ServiceReferenceServiceTupleComparator<>(_comparator);
 
-			_serviceReferences = new PriorityQueue<>(
-				1, serviceReferenceServiceTupleComparator);
+			_serviceReferences = new ArrayList<>(1);
 		}
 
 		@Override
@@ -77,10 +76,11 @@ public class SingleValueServiceTrackerBucketFactory<SR, TS>
 
 			_serviceReferences.remove(serviceReferenceServiceTuple);
 
-			ServiceReferenceServiceTuple<SR, TS>
-				headServiceReferenceServiceTuple = _serviceReferences.peek();
+			if (!_serviceReferences.isEmpty()) {
+				ServiceReferenceServiceTuple<SR, TS>
+					headServiceReferenceServiceTuple = _serviceReferences.get(
+						0);
 
-			if (headServiceReferenceServiceTuple != null) {
 				_service = headServiceReferenceServiceTuple.getService();
 			}
 			else {
@@ -94,15 +94,19 @@ public class SingleValueServiceTrackerBucketFactory<SR, TS>
 
 			_serviceReferences.add(serviceReferenceServiceTuple);
 
+			_serviceReferences.sort(_serviceReferenceServiceTupleComparator);
+
 			ServiceReferenceServiceTuple<SR, TS>
-				headServiceReferenceServiceTuple = _serviceReferences.peek();
+				headServiceReferenceServiceTuple = _serviceReferences.get(0);
 
 			_service = headServiceReferenceServiceTuple.getService();
 		}
 
 		private TS _service;
-		private final PriorityQueue<ServiceReferenceServiceTuple<SR, TS>>
+		private final List<ServiceReferenceServiceTuple<SR, TS>>
 			_serviceReferences;
+		private final ServiceReferenceServiceTupleComparator<SR>
+			_serviceReferenceServiceTupleComparator;
 
 	}
 

--- a/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ListServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ListServiceTrackerMapTest.java
@@ -247,6 +247,69 @@ public class ListServiceTrackerMapTest {
 	}
 
 	@Test
+	public void testGetServiceWithChangingServiceRanking() {
+		ServiceTrackerMap<String, List<TrackedOne>> serviceTrackerMap =
+			createServiceTrackerMap(_bundleContext);
+
+		TrackedOne trackedOne1 = new TrackedOne();
+
+		registerService(trackedOne1, 1);
+
+		TrackedOne trackedOne3 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration = registerService(
+			trackedOne3, 3);
+
+		TrackedOne trackedOne2 = new TrackedOne();
+
+		registerService(trackedOne2, 2);
+
+		List<TrackedOne> services = serviceTrackerMap.getService("aTarget");
+
+		Assert.assertEquals(services.toString(), 3, services.size());
+
+		Iterator<? extends TrackedOne> iterator = services.iterator();
+
+		Assert.assertEquals(trackedOne3, iterator.next());
+		Assert.assertEquals(trackedOne2, iterator.next());
+		Assert.assertEquals(trackedOne1, iterator.next());
+
+		Hashtable<String, Object> properties = new Hashtable<>();
+
+		properties.put("service.ranking", 0);
+		properties.put("target", "aTarget");
+
+		serviceRegistration.setProperties(properties);
+
+		services = serviceTrackerMap.getService("aTarget");
+
+		Assert.assertEquals(services.toString(), 3, services.size());
+
+		iterator = services.iterator();
+
+		Assert.assertEquals(trackedOne2, iterator.next());
+		Assert.assertEquals(trackedOne1, iterator.next());
+		Assert.assertEquals(trackedOne3, iterator.next());
+
+		properties = new Hashtable<>();
+
+		properties.put("service.ranking", 3);
+		properties.put("target", "aTarget");
+
+		serviceRegistration.setProperties(properties);
+
+		services = serviceTrackerMap.getService("aTarget");
+
+		Assert.assertEquals(services.toString(), 3, services.size());
+
+		iterator = services.iterator();
+
+		Assert.assertEquals(trackedOne3, iterator.next());
+		Assert.assertEquals(trackedOne2, iterator.next());
+		Assert.assertEquals(trackedOne1, iterator.next());
+	}
+
+	@Test
 	public void testGetServiceWithCustomComparatorReturningZero() {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
 			_bundleContext, TrackedOne.class, null,

--- a/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ListServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ListServiceTrackerMapTest.java
@@ -358,6 +358,54 @@ public class ListServiceTrackerMapTest {
 	}
 
 	@Test
+	public void testGetServiceWithRegisteredServiceRanking() {
+		ServiceTrackerMap<String, List<TrackedOne>> serviceTrackerMap =
+			createServiceTrackerMap(_bundleContext);
+
+		TrackedOne trackedOne1 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration1 = registerService(
+			trackedOne1);
+
+		TrackedOne trackedOne2 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration2 = registerService(
+			trackedOne2, 0);
+
+		List<TrackedOne> services = serviceTrackerMap.getService("aTarget");
+
+		Assert.assertEquals(services.toString(), 2, services.size());
+
+		Iterator<TrackedOne> iterator = services.iterator();
+
+		Assert.assertEquals(trackedOne1, iterator.next());
+		Assert.assertEquals(trackedOne2, iterator.next());
+
+		serviceRegistration1.unregister();
+
+		serviceRegistration1 = registerService(trackedOne1);
+
+		TrackedOne trackedOne3 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration3 = registerService(
+			trackedOne3, 1);
+
+		services = serviceTrackerMap.getService("aTarget");
+
+		Assert.assertEquals(services.toString(), 3, services.size());
+
+		iterator = services.iterator();
+
+		Assert.assertEquals(trackedOne3, iterator.next());
+		Assert.assertEquals(trackedOne2, iterator.next());
+		Assert.assertEquals(trackedOne1, iterator.next());
+
+		serviceRegistration3.unregister();
+		serviceRegistration2.unregister();
+		serviceRegistration1.unregister();
+	}
+
+	@Test
 	public void testGetServiceWithSimpleRegistration() {
 		ServiceTrackerMap<String, List<TrackedOne>> serviceTrackerMap =
 			createServiceTrackerMap(_bundleContext);

--- a/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ListServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ListServiceTrackerMapTest.java
@@ -251,18 +251,20 @@ public class ListServiceTrackerMapTest {
 		ServiceTrackerMap<String, List<TrackedOne>> serviceTrackerMap =
 			createServiceTrackerMap(_bundleContext);
 
-		TrackedOne trackedOne1 = new TrackedOne();
+		TrackedOne trackedOne2 = new TrackedOne();
 
-		registerService(trackedOne1, 1);
+		ServiceRegistration<TrackedOne> serviceRegistration2 = registerService(
+			trackedOne2, 0);
 
 		TrackedOne trackedOne3 = new TrackedOne();
 
-		ServiceRegistration<TrackedOne> serviceRegistration = registerService(
-			trackedOne3, 3);
+		ServiceRegistration<TrackedOne> serviceRegistration3 = registerService(
+			trackedOne3, 1);
 
-		TrackedOne trackedOne2 = new TrackedOne();
+		TrackedOne trackedOne1 = new TrackedOne();
 
-		registerService(trackedOne2, 2);
+		ServiceRegistration<TrackedOne> serviceRegistration1 = registerService(
+			trackedOne1, -1);
 
 		List<TrackedOne> services = serviceTrackerMap.getService("aTarget");
 
@@ -276,10 +278,10 @@ public class ListServiceTrackerMapTest {
 
 		Hashtable<String, Object> properties = new Hashtable<>();
 
-		properties.put("service.ranking", 0);
+		properties.put("service.ranking", -2);
 		properties.put("target", "aTarget");
 
-		serviceRegistration.setProperties(properties);
+		serviceRegistration3.setProperties(properties);
 
 		services = serviceTrackerMap.getService("aTarget");
 
@@ -293,10 +295,10 @@ public class ListServiceTrackerMapTest {
 
 		properties = new Hashtable<>();
 
-		properties.put("service.ranking", 3);
+		properties.put("service.ranking", 1);
 		properties.put("target", "aTarget");
 
-		serviceRegistration.setProperties(properties);
+		serviceRegistration3.setProperties(properties);
 
 		services = serviceTrackerMap.getService("aTarget");
 
@@ -307,6 +309,27 @@ public class ListServiceTrackerMapTest {
 		Assert.assertEquals(trackedOne3, iterator.next());
 		Assert.assertEquals(trackedOne2, iterator.next());
 		Assert.assertEquals(trackedOne1, iterator.next());
+
+		properties = new Hashtable<>();
+
+		properties.put("target", "aTarget");
+
+		serviceRegistration2.setProperties(properties);
+		serviceRegistration3.setProperties(properties);
+
+		services = serviceTrackerMap.getService("aTarget");
+
+		Assert.assertEquals(services.toString(), 3, services.size());
+
+		iterator = services.iterator();
+
+		Assert.assertEquals(trackedOne2, iterator.next());
+		Assert.assertEquals(trackedOne3, iterator.next());
+		Assert.assertEquals(trackedOne1, iterator.next());
+
+		serviceRegistration1.unregister();
+		serviceRegistration2.unregister();
+		serviceRegistration3.unregister();
 	}
 
 	@Test

--- a/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ObjectServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ObjectServiceTrackerMapTest.java
@@ -495,6 +495,49 @@ public class ObjectServiceTrackerMapTest {
 	}
 
 	@Test
+	public void testGetServiceWithRegisteredServiceRanking() {
+		ServiceTrackerMap<String, TrackedOne> serviceTrackerMap =
+			createServiceTrackerMap(_bundleContext);
+
+		TrackedOne trackedOne1 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration1 = registerService(
+			trackedOne1);
+
+		TrackedOne trackedOne2 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration2 = registerService(
+			trackedOne2, 0);
+
+		Assert.assertEquals(
+			trackedOne1, serviceTrackerMap.getService("aTarget"));
+
+		serviceRegistration1.unregister();
+
+		serviceRegistration1 = registerService(trackedOne1);
+
+		TrackedOne trackedOne3 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration3 = registerService(
+			trackedOne3, 1);
+
+		Assert.assertEquals(
+			trackedOne3, serviceTrackerMap.getService("aTarget"));
+
+		serviceRegistration3.unregister();
+
+		Assert.assertEquals(
+			trackedOne2, serviceTrackerMap.getService("aTarget"));
+
+		serviceRegistration2.unregister();
+
+		Assert.assertEquals(
+			trackedOne1, serviceTrackerMap.getService("aTarget"));
+
+		serviceRegistration1.unregister();
+	}
+
+	@Test
 	public void testGetServiceWithServiceTrackerCustomizer() {
 		ServiceTrackerMap<String, TrackedTwo> serviceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(

--- a/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ObjectServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ObjectServiceTrackerMapTest.java
@@ -224,6 +224,52 @@ public class ObjectServiceTrackerMapTest {
 	}
 
 	@Test
+	public void testGetServiceWithChangingServiceRanking() {
+		ServiceTrackerMap<String, TrackedOne> serviceTrackerMap =
+			createServiceTrackerMap(_bundleContext);
+
+		TrackedOne trackedOne1 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration1 = registerService(
+			trackedOne1, 3);
+
+		TrackedOne trackedOne2 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration2 = registerService(
+			trackedOne2, 2);
+
+		TrackedOne trackedOne3 = new TrackedOne();
+
+		ServiceRegistration<TrackedOne> serviceRegistration3 = registerService(
+			trackedOne3, 1);
+
+		Assert.assertEquals(
+			trackedOne1, serviceTrackerMap.getService("aTarget"));
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put("service.ranking", 0);
+		properties.put("target", "aTarget");
+
+		serviceRegistration1.setProperties(properties);
+
+		Assert.assertEquals(
+			trackedOne2, serviceTrackerMap.getService("aTarget"));
+
+		serviceRegistration2.unregister();
+
+		Assert.assertEquals(
+			trackedOne3, serviceTrackerMap.getService("aTarget"));
+
+		serviceRegistration3.unregister();
+
+		Assert.assertEquals(
+			trackedOne1, serviceTrackerMap.getService("aTarget"));
+
+		serviceRegistration1.unregister();
+	}
+
+	@Test
 	public void testGetServiceWithCustomComparator() {
 		ServiceReferenceMapper<String, TrackedOne>
 			propertyServiceReferenceMapper =


### PR DESCRIPTION
Hi Carlos. Instead of integrating my original test for service [un]registration handling, I have implemented new ones in similar style to yours. I tweaked yours too to ensure we are testing ranking behaviour when service.ranking isn't specified for a service.