### PR TITLE
LPS-89566 Use new InetAddress utility for requests

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java
@@ -48,7 +48,6 @@ import com.liferay.portal.util.PropsValues;
 
 import java.io.IOException;
 
-import java.net.InetAddress;
 import java.net.URL;
 
 import java.util.HashMap;
@@ -377,7 +376,7 @@ public class PingbackMethodImpl implements Method {
 			URL url = new URL(_sourceURI);
 
 			return InetAddressUtil.isLocalInetAddress(
-				InetAddress.getByName(url.getHost()));
+				InetAddressUtil.getInetAddressByName(url.getHost()));
 		}
 		catch (Exception e) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/internal/jabber/JabberImpl.java
+++ b/modules/apps/chat/chat-service/src/main/java/com/liferay/chat/internal/jabber/JabberImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ContactConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -414,7 +415,8 @@ public class JabberImpl implements Jabber {
 		String jabberHost = _chatGroupServiceConfiguration.jabberHost();
 
 		if (!Validator.isIPAddress(jabberHost)) {
-			InetAddress inetAddress = InetAddress.getByName(jabberHost);
+			InetAddress inetAddress = InetAddressUtil.getInetAddressByName(
+				jabberHost);
 
 			jabberHost = inetAddress.getHostAddress();
 		}

--- a/modules/apps/network-utilities/network-utilities-web/src/main/java/com/liferay/network/utilities/web/internal/util/DNSLookupWebCacheItem.java
+++ b/modules/apps/network-utilities/network-utilities-web/src/main/java/com/liferay/network/utilities/web/internal/util/DNSLookupWebCacheItem.java
@@ -17,6 +17,7 @@ package com.liferay.network.utilities.web.internal.util;
 import com.liferay.network.utilities.web.internal.model.DNSLookup;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.webcache.WebCacheException;
 import com.liferay.portal.kernel.webcache.WebCacheItem;
@@ -45,7 +46,8 @@ public class DNSLookupWebCacheItem implements WebCacheItem {
 
 			for (char c : array) {
 				if ((c != '.') && !Character.isDigit(c)) {
-					InetAddress inetAddress = InetAddress.getByName(_domain);
+					InetAddress inetAddress =
+						InetAddressUtil.getInetAddressByName(_domain);
 
 					results = inetAddress.getHostAddress();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/LiferayAccessTokenService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/LiferayAccessTokenService.java
@@ -15,6 +15,7 @@
 package com.liferay.oauth2.provider.rest.internal.endpoint.access.token;
 
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.remote.cors.annotation.CORS;
 
 import java.net.InetAddress;
@@ -69,7 +70,8 @@ public class LiferayAccessTokenService extends AccessTokenService {
 		String remoteHost = httpServletRequest.getRemoteHost();
 
 		try {
-			InetAddress inetAddress = InetAddress.getByName(remoteAddr);
+			InetAddress inetAddress = InetAddressUtil.getInetAddressByName(
+				remoteAddr);
 
 			remoteHost = inetAddress.getCanonicalHostName();
 		}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnection.java
@@ -19,6 +19,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -103,7 +104,7 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 
 		int port = GetterUtil.getInteger(transportAddressParts[1]);
 
-		InetAddress inetAddress = InetAddress.getByName(host);
+		InetAddress inetAddress = InetAddressUtil.getInetAddressByName(host);
 
 		transportClient.addTransportAddress(
 			new TransportAddress(inetAddress, port));

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.xsl.XSLURIResolver;
 
-import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -52,7 +51,7 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 			URL url = new URL(href);
 
 			if (InetAddressUtil.isLocalInetAddress(
-					InetAddress.getByName(url.getHost()))) {
+					InetAddressUtil.getInetAddressByName(url.getHost()))) {
 
 				throw new TransformerException(
 					StringBundler.concat(

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -374,6 +374,9 @@
 	<bean class="com.liferay.portal.kernel.util.HttpUtil" id="com.liferay.portal.kernel.util.HttpUtil">
 		<property name="http" ref="com.liferay.portal.util.HttpImpl" />
 	</bean>
+	<bean class="com.liferay.portal.kernel.util.InetAddressUtil" id="com.liferay.portal.kernel.util.InetAddressUtil">
+		<property name="inetAddressProvider" ref="com.liferay.portal.util.InetAddressProviderImpl" />
+	</bean>
 	<bean class="com.liferay.portal.kernel.util.LocalizationUtil" id="com.liferay.portal.kernel.util.LocalizationUtil">
 		<property name="localization">
 			<bean class="com.liferay.portal.util.LocalizationImpl" />
@@ -490,6 +493,7 @@
 	<bean class="com.liferay.portal.template.ThemeResourceParser" id="com.liferay.portal.template.ThemeResourceParser" />
 	<bean class="com.liferay.portal.util.HtmlImpl" id="com.liferay.portal.util.HtmlImpl" />
 	<bean class="com.liferay.portal.util.HttpImpl" id="com.liferay.portal.util.HttpImpl" />
+	<bean class="com.liferay.portal.util.InetAddressProviderImpl" id="com.liferay.portal.util.InetAddressProviderImpl" />
 	<bean class="com.liferay.portal.util.PortalImpl" id="com.liferay.portal.util.Portal" />
 	<bean class="com.liferay.portal.verify.model.AssetTagVerifiableModel" />
 	<bean class="com.liferay.portal.verify.model.GroupVerifiableResourcedModel" />

--- a/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
+++ b/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
@@ -94,7 +94,6 @@ import com.liferay.portal.struts.TilesUtil;
 import java.io.IOException;
 import java.io.InputStream;
 
-import java.net.InetAddress;
 import java.net.URL;
 
 import java.util.Collections;
@@ -1385,7 +1384,7 @@ public class TemplateContextHelper {
 				URL url = new URL(location);
 
 				if (InetAddressUtil.isLocalInetAddress(
-						InetAddress.getByName(url.getHost()))) {
+						InetAddressUtil.getInetAddressByName(url.getHost()))) {
 
 					return true;
 				}

--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -557,7 +558,8 @@ public class HttpImpl implements Http {
 		try {
 			URL urlObj = new URL(url);
 
-			InetAddress address = InetAddress.getByName(urlObj.getHost());
+			InetAddress address = InetAddressUtil.getInetAddressByName(
+				urlObj.getHost());
 
 			return address.getHostAddress();
 		}

--- a/portal-impl/src/com/liferay/portal/util/InetAddressProviderImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/InetAddressProviderImpl.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.InetAddressProvider;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
+
+import java.util.Enumeration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Michael C. Han
+ * @author Shuyang Zhou
+ * @author Marta Medio
+ */
+public class InetAddressProviderImpl implements InetAddressProvider {
+
+	public InetAddress getInetAddressByName(String domain)
+		throws UnknownHostException {
+
+		InetAddress inetAddress = null;
+
+		int i = _atomicInteger.decrementAndGet();
+
+		try {
+			if (i > 0) {
+				Future<InetAddress> result = _executorService.submit(
+					() -> InetAddress.getByName(domain));
+
+				inetAddress = result.get(
+					PropsValues.DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS,
+					TimeUnit.SECONDS);
+			}
+			else {
+				_log.error(
+					"Thread limit exceeded to determine address for host: " +
+						domain);
+			}
+		}
+		catch (ExecutionException | InterruptedException | TimeoutException e) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(e, e);
+			}
+
+			throw new UnknownHostException("Unable to resolve URL: " + domain);
+		}
+		finally {
+			_atomicInteger.incrementAndGet();
+		}
+
+		return inetAddress;
+	}
+
+	public String getLocalHostName() throws Exception {
+		String localHostName;
+
+		try {
+			InetAddress inetAddress = _getLocalInetAddress();
+
+			localHostName = inetAddress.getHostName();
+		}
+		catch (Exception e) {
+			throw new ExceptionInInitializerError(e);
+		}
+
+		return localHostName;
+	}
+
+	public InetAddress getLoopbackInetAddress() throws UnknownHostException {
+		return InetAddress.getByName("127.0.0.1");
+	}
+
+	public boolean isLocalInetAddress(InetAddress inetAddress) {
+		if (inetAddress.isAnyLocalAddress() ||
+			inetAddress.isLinkLocalAddress() ||
+			inetAddress.isLoopbackAddress() ||
+			inetAddress.isSiteLocalAddress()) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private InetAddress _getLocalInetAddress() throws Exception {
+		Enumeration<NetworkInterface> enu1 =
+			NetworkInterface.getNetworkInterfaces();
+
+		while (enu1.hasMoreElements()) {
+			NetworkInterface networkInterface = enu1.nextElement();
+
+			Enumeration<InetAddress> enu2 = networkInterface.getInetAddresses();
+
+			while (enu2.hasMoreElements()) {
+				InetAddress inetAddress = enu2.nextElement();
+
+				if (!inetAddress.isLoopbackAddress() &&
+					(inetAddress instanceof Inet4Address)) {
+
+					return inetAddress;
+				}
+			}
+		}
+
+		throw new SystemException("No local internet address");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		InetAddressProviderImpl.class);
+
+	private static final AtomicInteger _atomicInteger = new AtomicInteger(
+		PropsValues.DNS_SECURITY_THREAD_LIMIT);
+	private static final ExecutorService _executorService =
+		Executors.newFixedThreadPool(PropsValues.DNS_SECURITY_THREAD_LIMIT);
+
+}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -170,6 +170,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.InheritableMap;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListMergeable;
@@ -999,7 +1000,8 @@ public class PortalImpl implements Portal {
 			}
 
 			try {
-				InetAddress inetAddress = InetAddress.getByName(domain);
+				InetAddress inetAddress = InetAddressUtil.getInetAddressByName(
+					domain);
 
 				String hostAddress = inetAddress.getHostAddress();
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1118,6 +1118,13 @@ public class PropsValues {
 	public static String DL_WEBDAV_SUBSTITUTION_CHAR = PropsUtil.get(
 		PropsKeys.DL_WEBDAV_SUBSTITUTION_CHAR);
 
+	public static final int DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS =
+		GetterUtil.getInteger(
+			PropsUtil.get(PropsKeys.DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS));
+
+	public static final int DNS_SECURITY_THREAD_LIMIT = GetterUtil.getInteger(
+		PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT));
+
 	public static final String[] DYNAMIC_RESOURCE_SERVLET_ALLOWED_PATHS =
 		PropsUtil.getArray(PropsKeys.DYNAMIC_RESOURCE_SERVLET_ALLOWED_PATHS);
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -10677,6 +10677,26 @@
     dl.webdav.substitution.char=^
 
 ##
+## DNS
+##
+
+    #
+    # Configure the seconds to wait for resolving an external domain,
+    # this limit helps to avoid possible DoS attacks to the Portal.
+    #
+    # Env: LIFERAY_DNS_PERIOD_SECURITY_PERIOD_ADDRESS_PERIOD_TIMEOUT_PERIOD_SECONDS
+    #
+    dns.security.address.timeout.seconds=2
+
+    #
+    # Configure the maximum number of threads when resolving an external domain,
+    # this limit helps to avoid possible DoS attacks to the Portal.
+    #
+    # Env: LIFERAY_DNS_PERIOD_SECURITY_PERIOD_THREAD_PERIOD_LIMIT
+    #
+    dns.security.thread.limit=10
+
+##
 ## IFrame Portlet
 ##
 

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/security/access/control/AllowedIPAddressesValidatorFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/security/access/control/AllowedIPAddressesValidatorFactory.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -43,12 +44,14 @@ public final class AllowedIPAddressesValidatorFactory {
 		try {
 			if (Validator.isIPv4Address(ipAddressAndNetmask[0])) {
 				return new V4AllowedIPAddressesValidator(
-					InetAddress.getByName(ipAddressAndNetmask[0]),
+					InetAddressUtil.getInetAddressByName(
+						ipAddressAndNetmask[0]),
 					ipAddressAndNetmask);
 			}
 			else if (Validator.isIPv6Address(ipAddressAndNetmask[0])) {
 				return new V6AllowedIPAddressesValidator(
-					InetAddress.getByName(ipAddressAndNetmask[0]),
+					InetAddressUtil.getInetAddressByName(
+						ipAddressAndNetmask[0]),
 					ipAddressAndNetmask);
 			}
 			else {
@@ -81,7 +84,7 @@ public final class AllowedIPAddressesValidatorFactory {
 			InetAddress inetAddress = null;
 
 			try {
-				inetAddress = InetAddress.getByName(ipAddress);
+				inetAddress = InetAddressUtil.getInetAddressByName(ipAddress);
 			}
 			catch (UnknownHostException uhe) {
 				return false;
@@ -161,7 +164,8 @@ public final class AllowedIPAddressesValidatorFactory {
 		private byte[] _getNetmaskFromDotNotation(String netmask)
 			throws UnknownHostException {
 
-			InetAddress inetAddress = InetAddress.getByName(netmask);
+			InetAddress inetAddress = InetAddressUtil.getInetAddressByName(
+				netmask);
 
 			return inetAddress.getAddress();
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+import aQute.bnd.annotation.ProviderType;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * @author Marta Medio
+ */
+@ProviderType
+public interface InetAddressProvider {
+
+	public InetAddress getInetAddressByName(String domain)
+		throws UnknownHostException;
+
+	public String getLocalHostName() throws Exception;
+
+	public InetAddress getLoopbackInetAddress() throws UnknownHostException;
+
+	public boolean isLocalInetAddress(InetAddress inetAddress);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -14,81 +14,46 @@
 
 package com.liferay.portal.kernel.util;
 
-import com.liferay.portal.kernel.exception.SystemException;
-
-import java.net.Inet4Address;
 import java.net.InetAddress;
-import java.net.NetworkInterface;
 import java.net.UnknownHostException;
-
-import java.util.Enumeration;
 
 /**
  * @author Michael C. Han
  * @author Shuyang Zhou
+ * @author Marta Medio
  */
 public class InetAddressUtil {
 
-	public static String getLocalHostName() throws Exception {
-		return LocalHostNameHolder._LOCAL_HOST_NAME;
+	public static InetAddress getInetAddressByName(String domain)
+		throws UnknownHostException {
+
+		return getInetAddressProvider().getInetAddressByName(domain);
 	}
 
-	public static InetAddress getLocalInetAddress() throws Exception {
-		Enumeration<NetworkInterface> enu1 =
-			NetworkInterface.getNetworkInterfaces();
+	public static InetAddressProvider getInetAddressProvider() {
+		return _inetAddressProvider;
+	}
 
-		while (enu1.hasMoreElements()) {
-			NetworkInterface networkInterface = enu1.nextElement();
-
-			Enumeration<InetAddress> enu2 = networkInterface.getInetAddresses();
-
-			while (enu2.hasMoreElements()) {
-				InetAddress inetAddress = enu2.nextElement();
-
-				if (!inetAddress.isLoopbackAddress() &&
-					(inetAddress instanceof Inet4Address)) {
-
-					return inetAddress;
-				}
-			}
-		}
-
-		throw new SystemException("No local internet address");
+	public static String getLocalHostName() throws Exception {
+		return getInetAddressProvider().getLocalHostName();
 	}
 
 	public static InetAddress getLoopbackInetAddress()
 		throws UnknownHostException {
 
-		return InetAddress.getByName("127.0.0.1");
+		return getInetAddressProvider().getLoopbackInetAddress();
 	}
 
 	public static boolean isLocalInetAddress(InetAddress inetAddress) {
-		if (inetAddress.isAnyLocalAddress() ||
-			inetAddress.isLinkLocalAddress() ||
-			inetAddress.isLoopbackAddress() ||
-			inetAddress.isSiteLocalAddress()) {
-
-			return true;
-		}
-
-		return false;
+		return getInetAddressProvider().isLocalInetAddress(inetAddress);
 	}
 
-	private static class LocalHostNameHolder {
+	public static void setInetAddressProvider(
+		InetAddressProvider inetAddressProvider) {
 
-		private static final String _LOCAL_HOST_NAME;
-
-		static {
-			try {
-				InetAddress inetAddress = getLocalInetAddress();
-
-				_LOCAL_HOST_NAME = inetAddress.getHostName();
-			}
-			catch (Exception e) {
-				throw new ExceptionInInitializerError(e);
-			}
-		}
-
+		_inetAddressProvider = inetAddressProvider;
 	}
+
+	private static InetAddressProvider _inetAddressProvider;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1185,6 +1185,12 @@ public interface PropsKeys {
 	public static final String DL_WEBDAV_SUBSTITUTION_CHAR =
 		"dl.webdav.substitution.char";
 
+	public static final String DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS =
+		"dns.security.address.timeout.seconds";
+
+	public static final String DNS_SECURITY_THREAD_LIMIT =
+		"dns.security.thread.limit";
+
 	public static final String DYNAMIC_RESOURCE_SERVLET_ALLOWED_PATHS =
 		"dynamic.resource.servlet.allowed.paths";
 


### PR DESCRIPTION
Hey Carlos

As we discussed, I have created a new method inside the existing IntAddress Utility that limits by time and threads the use of `InetAddress.getByName`. I've had to change the architecture from the old `InetAddressUtil` into a new `InetAddressResolverImpl` to use the portal.properties for set up limits.

The problem of the issue is solved [here](https://github.com/csierra/liferay-portal/pull/502/files#diff-97d14104465a5b7ecb93c57d8ffbb75a), but I applied the security prevention to another calls on the Portal; please, check it out