### PR TITLE
LPS-96708 ServiceTracker PropertyServiceReferenceMapper does not handle List type properties

### DIFF
--- a/modules/core/osgi-service-tracker-collections-test/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ObjectServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-collections-test/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ObjectServiceTrackerMapTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Dictionary;
@@ -405,6 +406,19 @@ public class ObjectServiceTrackerMapTest {
 			registerService(new TrackedOne(), "anotherTarget"));
 
 		Assert.assertNull(serviceTrackerMap.getService("aTarget"));
+	}
+
+	@Test
+	public void testGetServiceWithListProperty() {
+		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+			_bundleContext, null, "target");
+
+		_serviceRegistrations.add(
+			registerService(
+				new TrackedOne(), Arrays.asList("target1", "target2")));
+
+		Assert.assertNotNull(_serviceTrackerMap.getService("target1"));
+		Assert.assertNotNull(_serviceTrackerMap.getService("target2"));
 	}
 
 	@Test
@@ -866,6 +880,17 @@ public class ObjectServiceTrackerMapTest {
 
 		return _bundleContext.registerService(
 			TrackedOne.class, trackedOne, properties);
+	}
+
+	protected ServiceRegistration<TrackedOne> registerService(
+		TrackedOne service, List<String> targets) {
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put("target", targets);
+
+		return _bundleContext.registerService(
+			TrackedOne.class, service, properties);
 	}
 
 	protected ServiceRegistration<TrackedOne> registerService(

--- a/modules/core/osgi-service-tracker-collections/src/main/java/com/liferay/osgi/service/tracker/collections/map/PropertyServiceReferenceMapper.java
+++ b/modules/core/osgi-service-tracker-collections/src/main/java/com/liferay/osgi/service/tracker/collections/map/PropertyServiceReferenceMapper.java
@@ -14,6 +14,8 @@
 
 package com.liferay.osgi.service.tracker.collections.map;
 
+import java.util.Collection;
+
 import org.osgi.framework.ServiceReference;
 
 /**
@@ -36,6 +38,11 @@ public class PropertyServiceReferenceMapper<T, S>
 
 		if (propertyValue instanceof Object[]) {
 			for (T t : (T[])propertyValue) {
+				emitter.emit(t);
+			}
+		}
+		else if (propertyValue instanceof Collection) {
+			for (T t : (Collection<T>)propertyValue) {
 				emitter.emit(t);
 			}
 		}


### PR DESCRIPTION
Hi Carlos. Here's the fix which is required for language extender to support attributes like ```bundle.symbolic.name:List="bundle1,bundle2";\ ```.

Also, I think we could improve the integration tests by having each test unregister the services it registers?