### PR TITLE
OAUTH2-254 BearerTokenProvider.AccessToken.getScopes() must return scope aliases

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/security/auth/verifier/OAuth2JSONWSAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/security/auth/verifier/OAuth2JSONWSAuthVerifier.java
@@ -19,17 +19,15 @@ import com.liferay.oauth2.provider.jsonws.internal.service.access.policy.scope.S
 import com.liferay.oauth2.provider.jsonws.internal.service.access.policy.scope.SAPEntryScopeDescriptorFinderRegistrator;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
-import com.liferay.oauth2.provider.model.OAuth2ScopeGrant;
-import com.liferay.oauth2.provider.model.OAuth2ScopeGrantModel;
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProvider;
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProviderAccessor;
+import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
 import com.liferay.oauth2.provider.scope.liferay.OAuth2ProviderScopeLiferayConstants;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
-import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -45,6 +43,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -54,7 +53,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -111,7 +109,21 @@ public class OAuth2JSONWSAuthVerifier implements AuthVerifier {
 				return authVerifierResult;
 			}
 
-			Set<String> scopes = new HashSet<>(accessToken.getScopes());
+			Set<String> scopes = new HashSet<>();
+
+			for (String scope : accessToken.getScopes()) {
+				for (String jaxRsApplicationName : _jaxRsApplicationNames) {
+					Collection<LiferayOAuth2Scope> liferayOAuth2Scopes =
+						_scopeLocator.getLiferayOAuth2Scopes(
+							companyId, scope, jaxRsApplicationName);
+
+					for (LiferayOAuth2Scope liferayOAuth2Scope :
+							liferayOAuth2Scopes) {
+
+						scopes.add(liferayOAuth2Scope.getScope());
+					}
+				}
+			}
 
 			List<SAPEntryScope> sapEntryScopes =
 				_sapEntryScopeDescriptorFinderRegistrator.
@@ -218,18 +230,16 @@ public class OAuth2JSONWSAuthVerifier implements AuthVerifier {
 
 		long issuedAt = createDate.getTime() / 1000;
 
-		List<OAuth2ScopeGrant> oAuth2AuthorizationOAuth2ScopeGrants =
-			_oAuth2ScopeGrantLocalService.
-				getOAuth2AuthorizationOAuth2ScopeGrants(
-					oAuth2Authorization.getOAuth2AuthorizationId());
+		List<String> scopeAliasesList = Collections.emptyList();
 
-		List<String> scopeAliasesList =
-			oAuth2AuthorizationOAuth2ScopeGrants.stream(
-			).map(
-				OAuth2ScopeGrantModel::getScope
-			).collect(
-				Collectors.toList()
-			);
+		long oAuth2ApplicationScopeAliasesId =
+			oAuth2Authorization.getOAuth2ApplicationScopeAliasesId();
+
+		if (oAuth2ApplicationScopeAliasesId > 0) {
+			scopeAliasesList =
+				_oAuth2ApplicationScopeAliasesLocalService.getScopeAliasesList(
+					oAuth2ApplicationScopeAliasesId);
+		}
 
 		return new BearerTokenProvider.AccessToken(
 			oAuth2Application, new ArrayList<>(), StringPool.BLANK, expiresIn,
@@ -271,9 +281,6 @@ public class OAuth2JSONWSAuthVerifier implements AuthVerifier {
 
 	@Reference
 	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
-
-	@Reference
-	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
 
 	@Reference
 	private SAPEntryScopeDescriptorFinderRegistrator


### PR DESCRIPTION
... because the AccessToken instance is sent to a SPI service and hence must be consistent for all callouts.