### PR TITLE
[TS] LPS-98254 X-Forwarded-* headers are not being honored when main.servlet.https.required is set to true

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -23,9 +23,9 @@ import com.liferay.portal.kernel.security.auth.AccessControlContext;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
 import com.liferay.portal.kernel.servlet.ProtectedServletRequest;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.AuthVerifierPipeline;
@@ -237,7 +237,7 @@ public class AuthVerifierFilter extends BasePortalFilter {
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
-		if (!_httpsRequired || httpServletRequest.isSecure()) {
+		if (!_httpsRequired || PortalUtil.isSecure(httpServletRequest)) {
 			return false;
 		}
 
@@ -247,11 +247,10 @@ public class AuthVerifierFilter extends BasePortalFilter {
 			_log.debug("Securing " + completeURL);
 		}
 
-		StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(4);
 
-		sb.append(Http.HTTPS_WITH_SLASH);
-		sb.append(httpServletRequest.getServerName());
-		sb.append(httpServletRequest.getServletPath());
+		sb.append(PortalUtil.getPortalURL(httpServletRequest, true));
+		sb.append(httpServletRequest.getRequestURI());
 
 		if (Validator.isNotNull(httpServletRequest.getQueryString())) {
 			sb.append(StringPool.QUESTION);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -247,9 +247,10 @@ public class AuthVerifierFilter extends BasePortalFilter {
 			_log.debug("Securing " + completeURL);
 		}
 
-		StringBundler sb = new StringBundler(4);
+		StringBundler sb = new StringBundler(5);
 
 		sb.append(PortalUtil.getPortalURL(httpServletRequest, true));
+		sb.append(PortalUtil.getPathContext(httpServletRequest));
 		sb.append(httpServletRequest.getRequestURI());
 
 		if (Validator.isNotNull(httpServletRequest.getQueryString())) {

--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
@@ -281,9 +281,10 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 				_log.debug("Securing " + completeURL);
 			}
 
-			StringBundler sb = new StringBundler(4);
+			StringBundler sb = new StringBundler(5);
 
 			sb.append(PortalUtil.getPortalURL(httpServletRequest, true));
+			sb.append(PortalUtil.getPathContext(httpServletRequest));
 			sb.append(httpServletRequest.getRequestURI());
 
 			if (Validator.isNotNull(httpServletRequest.getQueryString())) {

--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.ProtectedServletRequest;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -274,7 +273,7 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 			}
 		}
 
-		if (_httpsRequired && !httpServletRequest.isSecure()) {
+		if (_httpsRequired && !PortalUtil.isSecure(httpServletRequest)) {
 			if (_log.isDebugEnabled()) {
 				String completeURL = HttpUtil.getCompleteURL(
 					httpServletRequest);
@@ -282,11 +281,10 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 				_log.debug("Securing " + completeURL);
 			}
 
-			StringBundler sb = new StringBundler(5);
+			StringBundler sb = new StringBundler(4);
 
-			sb.append(Http.HTTPS_WITH_SLASH);
-			sb.append(httpServletRequest.getServerName());
-			sb.append(httpServletRequest.getServletPath());
+			sb.append(PortalUtil.getPortalURL(httpServletRequest, true));
+			sb.append(httpServletRequest.getRequestURI());
 
 			if (Validator.isNotNull(httpServletRequest.getQueryString())) {
 				sb.append(StringPool.QUESTION);

--- a/portal-impl/test/integration/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilterTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilterTest.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.servlet.filters.authverifier;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Eric Yan
+ */
+public class AuthVerifierFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_authVerifierFilter = new AuthVerifierFilterTest.TestAuthFilter();
+		_mockFilterChain = new MockFilterChain();
+		_mockHttpServletRequest = new MockHttpServletRequest();
+		_mockHttpServletResponse = new MockHttpServletResponse();
+	}
+
+	@After
+	public void tearDown() {
+		AccessControlUtil.setAccessControlContext(null);
+	}
+
+	@Test
+	public void testHttpsRequiredDisabled() throws Exception {
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "false");
+
+		_authVerifierFilter.init(mockFilterConfig);
+
+		_authVerifierFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		Assert.assertNull(redirectURL);
+	}
+
+	@Test
+	public void testHttpsRequiredWithHttpRequest() throws Exception {
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "true");
+
+		_authVerifierFilter.init(mockFilterConfig);
+
+		_authVerifierFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		String expectedRedirectURL = "https://localhost";
+
+		Assert.assertEquals(expectedRedirectURL, redirectURL);
+	}
+
+	@Test
+	public void testHttpsRequiredWithHttpRequestAndXForwardedHostAndPortHeader()
+		throws Exception {
+
+		boolean webServerForwardedHostEnabled =
+			PropsValues.WEB_SERVER_FORWARDED_HOST_ENABLED;
+		boolean webServerForwardedPortEnabled =
+			PropsValues.WEB_SERVER_FORWARDED_PORT_ENABLED;
+
+		setPortalProperty("WEB_SERVER_FORWARDED_HOST_ENABLED", Boolean.TRUE);
+		setPortalProperty("WEB_SERVER_FORWARDED_PORT_ENABLED", Boolean.TRUE);
+
+		_mockHttpServletRequest.addHeader(
+			"X-Forwarded-Host", "test.liferay.com");
+		_mockHttpServletRequest.addHeader("X-Forwarded-Port", "1234");
+
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "true");
+
+		_authVerifierFilter.init(mockFilterConfig);
+
+		_authVerifierFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		setPortalProperty(
+			"WEB_SERVER_FORWARDED_HOST_ENABLED", webServerForwardedHostEnabled);
+		setPortalProperty(
+			"WEB_SERVER_FORWARDED_PORT_ENABLED", webServerForwardedPortEnabled);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		String expectedRedirectURL = "https://test.liferay.com:1234";
+
+		Assert.assertEquals(expectedRedirectURL, redirectURL);
+	}
+
+	@Test
+	public void testHttpsRequiredWithHttpRequestAndXForwardedProtoHeader()
+		throws Exception {
+
+		boolean webServerForwardedProtocolEnabled =
+			PropsValues.WEB_SERVER_FORWARDED_PROTOCOL_ENABLED;
+
+		setPortalProperty(
+			"WEB_SERVER_FORWARDED_PROTOCOL_ENABLED", Boolean.TRUE);
+
+		_mockHttpServletRequest.addHeader("X-Forwarded-Proto", Http.HTTPS);
+
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "true");
+
+		_authVerifierFilter.init(mockFilterConfig);
+
+		_authVerifierFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		setPortalProperty(
+			"WEB_SERVER_FORWARDED_PROTOCOL_ENABLED",
+			webServerForwardedProtocolEnabled);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		Assert.assertNull(redirectURL);
+	}
+
+	@Test
+	public void testHttpsRequiredWithHttpsRequest() throws Exception {
+		_mockHttpServletRequest.setScheme(Http.HTTPS);
+
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "true");
+
+		_authVerifierFilter.init(mockFilterConfig);
+
+		_authVerifierFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		Assert.assertNull(redirectURL);
+	}
+
+	protected void setPortalProperty(String propertyName, Object value)
+		throws Exception {
+
+		Field field = ReflectionUtil.getDeclaredField(
+			PropsValues.class, propertyName);
+
+		field.setAccessible(true);
+
+		Field modifiersField = Field.class.getDeclaredField("modifiers");
+
+		modifiersField.setAccessible(true);
+		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+		field.set(null, value);
+	}
+
+	private AuthVerifierFilter _authVerifierFilter;
+	private MockFilterChain _mockFilterChain;
+	private MockHttpServletRequest _mockHttpServletRequest;
+	private MockHttpServletResponse _mockHttpServletResponse;
+
+	private static class TestAuthFilter extends AuthVerifierFilter {
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.servlet.filters.secure;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Eric Yan
+ */
+public class BaseAuthFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_authFilter = new TestAuthFilter();
+		_mockFilterChain = new MockFilterChain();
+		_mockHttpServletRequest = new MockHttpServletRequest();
+		_mockHttpServletResponse = new MockHttpServletResponse();
+	}
+
+	@Test
+	public void testHttpsRequiredDisabled() throws Exception {
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "false");
+
+		_authFilter.init(mockFilterConfig);
+
+		_authFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		Assert.assertNull(redirectURL);
+	}
+
+	@Test
+	public void testHttpsRequiredWithHttpRequest() throws Exception {
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "true");
+
+		_authFilter.init(mockFilterConfig);
+
+		_authFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		String expectedRedirectURL = "https://localhost";
+
+		Assert.assertEquals(expectedRedirectURL, redirectURL);
+	}
+
+	@Test
+	public void testHttpsRequiredWithHttpRequestAndXForwardedHostAndPortHeader()
+		throws Exception {
+
+		boolean webServerForwardedHostEnabled =
+			PropsValues.WEB_SERVER_FORWARDED_HOST_ENABLED;
+		boolean webServerForwardedPortEnabled =
+			PropsValues.WEB_SERVER_FORWARDED_PORT_ENABLED;
+
+		setPortalProperty("WEB_SERVER_FORWARDED_HOST_ENABLED", Boolean.TRUE);
+		setPortalProperty("WEB_SERVER_FORWARDED_PORT_ENABLED", Boolean.TRUE);
+
+		_mockHttpServletRequest.addHeader(
+			"X-Forwarded-Host", "test.liferay.com");
+		_mockHttpServletRequest.addHeader("X-Forwarded-Port", "1234");
+
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "true");
+
+		_authFilter.init(mockFilterConfig);
+
+		_authFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		setPortalProperty(
+			"WEB_SERVER_FORWARDED_HOST_ENABLED", webServerForwardedHostEnabled);
+		setPortalProperty(
+			"WEB_SERVER_FORWARDED_PORT_ENABLED", webServerForwardedPortEnabled);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		String expectedRedirectURL = "https://test.liferay.com:1234";
+
+		Assert.assertEquals(expectedRedirectURL, redirectURL);
+	}
+
+	@Test
+	public void testHttpsRequiredWithHttpRequestAndXForwardedProtoHeader()
+		throws Exception {
+
+		boolean webServerForwardedProtocolEnabled =
+			PropsValues.WEB_SERVER_FORWARDED_PROTOCOL_ENABLED;
+
+		setPortalProperty(
+			"WEB_SERVER_FORWARDED_PROTOCOL_ENABLED", Boolean.TRUE);
+
+		_mockHttpServletRequest.addHeader("X-Forwarded-Proto", Http.HTTPS);
+
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "true");
+
+		_authFilter.init(mockFilterConfig);
+
+		_authFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		setPortalProperty(
+			"WEB_SERVER_FORWARDED_PROTOCOL_ENABLED",
+			webServerForwardedProtocolEnabled);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		Assert.assertNull(redirectURL);
+	}
+
+	@Test
+	public void testHttpsRequiredWithHttpsRequest() throws Exception {
+		_mockHttpServletRequest.setScheme(Http.HTTPS);
+
+		MockFilterConfig mockFilterConfig = new MockFilterConfig();
+
+		mockFilterConfig.addInitParameter("https.required", "true");
+
+		_authFilter.init(mockFilterConfig);
+
+		_authFilter.processFilter(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_mockFilterChain);
+
+		String redirectURL = _mockHttpServletResponse.getRedirectedUrl();
+
+		Assert.assertNull(redirectURL);
+	}
+
+	protected void setPortalProperty(String propertyName, Object value)
+		throws Exception {
+
+		Field field = ReflectionUtil.getDeclaredField(
+			PropsValues.class, propertyName);
+
+		field.setAccessible(true);
+
+		Field modifiersField = Field.class.getDeclaredField("modifiers");
+
+		modifiersField.setAccessible(true);
+		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+		field.set(null, value);
+	}
+
+	private BaseAuthFilter _authFilter;
+	private MockFilterChain _mockFilterChain;
+	private MockHttpServletRequest _mockHttpServletRequest;
+	private MockHttpServletResponse _mockHttpServletResponse;
+
+	private static class TestAuthFilter extends BaseAuthFilter {
+	}
+
+}

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -119,5 +119,10 @@
 
 		<suppress checks="JSONPackageJSONCheck" files="modules/apps/analytics/analytics-client-js/package\.json" />
 		<suppress checks="JSONPackageJSONCheck" files="modules/apps/segments/segments-web/package\.json" />
+
+		<!-- Temporary suppressions for adding tests for existing portal auth filters -->
+
+		<suppress checks="NewFileCheck" files="portal-impl/test/integration/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilterTest\.java" />
+		<suppress checks="NewFileCheck" files="portal-impl/test/integration/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest\.java" />
 	</source-check>
 </suppressions>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-98254

Hi Carlos,

@lipusz recently forwarded this pr to you, but we ran into some SF issues, which we decided to resolve, via source-formatter-supressions.xml.
- Reference: https://github.com/csierra/liferay-portal/pull/536

Below is the description from the previous pr:

> 
> The goal of this pr is to make sure **X-Forwarded-\* headers** are being accounted for.
> 
> **Additional Notes**
> 
> - For the steps to reproduce, applying the fix to BaseAuthFilter already resolves the issue.
>   - But, I noticed that AuthVerifierFilter had basically the same logic, so I made the changes there as well.
>   - I wasn't sure if we should consolidate the logic, since they are technically two different filters.
>   - And so, the approach I took was to just make changes to both filters and to create test classes for each filter.
> - I also noticed that the proxy path wasn't being accounted for, so I added to that as well.
> - Also, feel free to discard the tests if you feel they are not necessary.
> 
> Let us know if you have any concerns.
> 
> Regards,
> Tibor