### PR TITLE
LPS-98866 is this code needed?

### DIFF
--- a/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/OutputStreamContainerFactoryTrackerImpl.java
+++ b/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/OutputStreamContainerFactoryTrackerImpl.java
@@ -157,17 +157,6 @@ public class OutputStreamContainerFactoryTrackerImpl
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		Logger rootLogger = Logger.getRootLogger();
-
-		_writerAppender = new WriterAppender(
-			new SimpleLayout(), new ThreadLocalWriter());
-
-		_writerAppender.setThreshold(Level.ALL);
-
-		_writerAppender.activateOptions();
-
-		rootLogger.addAppender(_writerAppender);
-
 		_outputStreamContainerFactories =
 			ServiceTrackerMapFactory.openSingleValueMap(
 				bundleContext, OutputStreamContainerFactory.class, "name");
@@ -175,14 +164,8 @@ public class OutputStreamContainerFactoryTrackerImpl
 
 	@Deactivate
 	protected void deactivate() {
-		Logger rootLogger = Logger.getRootLogger();
-
 		if (_outputStreamContainerFactories != null) {
 			_outputStreamContainerFactories.close();
-		}
-
-		if (rootLogger != null) {
-			rootLogger.removeAppender(_writerAppender);
 		}
 	}
 
@@ -207,7 +190,6 @@ public class OutputStreamContainerFactoryTrackerImpl
 	)
 	private volatile OutputStreamContainerFactory _outputStreamContainerFactory;
 
-	private WriterAppender _writerAppender;
 	private final ThreadLocal<Writer> _writerThreadLocal = new ThreadLocal<>();
 
 	private class ThreadLocalWriter extends Writer {


### PR DESCRIPTION
Buenas Carlos,

Resulta que cuando se ejecuta el upgrade con la upgrade tool se está imprimiendo las trazas de upgrade de los módulos de OSGi (no pasa en el core) por duplicado (desde siempre empezando en 7.0). Si quito el código que te paso, todo va bien y no veo necesidad a priori de ello ni echo ninguna salida en falta. ¿Cuál es el propósito de este código? ¿podemos quitarlo?

Gracias!