### PR TITLE
LPS-101015 Embedded portlet properties need to be utilized if impleme…

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletConfigurationLayoutUtil;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletLayoutListener;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletQNameUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -58,7 +59,6 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Tuple;
 import com.liferay.portal.kernel.util.Validator;
@@ -843,7 +843,8 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 	}
 
 	protected PortletPreferences getPortletPreferences(
-		ThemeDisplay themeDisplay, String portletId, String settingsScope) {
+			ThemeDisplay themeDisplay, String portletId, String settingsScope)
+		throws PortalException {
 
 		Layout layout = themeDisplay.getLayout();
 
@@ -853,10 +854,9 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 			return null;
 		}
 
-		PortletPreferencesIds portletPreferencesIds = new PortletPreferencesIds(
-			themeDisplay.getCompanyId(), layout.getGroupId(),
-			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, PortletKeys.PREFS_PLID_SHARED,
-			portletId);
+		PortletPreferencesIds portletPreferencesIds =
+			PortletPreferencesFactoryUtil.getPortletPreferencesIds(
+				themeDisplay.getRequest(), layout, portletId);
 
 		return _portletPreferencesLocalService.getPreferences(
 			portletPreferencesIds);


### PR DESCRIPTION
/cc @brianikim

Notes from Brian:
> https://issues.liferay.com/browse/LPS-101015
> 
> The issue here is that Liferay is currently hard-coding portletPreferences for embedded portlets to be stored at the layout level.
> 
> The current implementation has the immediate consequence of ignoring portlet properties such as "com.liferay.portlet.preferences-company-wide" which allow portlet preferences to be stored at the company level so that the preferences are shared between same type of portlets across multiple pages.
> 
> The fix is to ensure that we utilize available methods that check for how the preferences should be stored.
> 
> Please let me know if you have any questions. Thanks.
> 
> Sincerely,
> Brian Kim