### PR TITLE
LPS-101216 PoC

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalInitialDataGeneration.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalInitialDataGeneration.java
@@ -1,0 +1,21 @@
+package com.liferay.journal.internal.upgrade;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.InitialDataGeneration;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	immediate = true, property = "Bundle-SymbolicName=com.liferay.journal.service",
+	service = InitialDataGeneration.class
+)
+public class JournalInitialDataGeneration implements InitialDataGeneration {
+
+	public void execute() throws UpgradeException {
+		_log.error("JournalInitialDataGeneration ejecutado");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalInitialDataGeneration.class);
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/InitialDataGeneration.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/InitialDataGeneration.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.upgrade;
+
+/**
+ * @author Alberto Chaparro
+ */
+public interface InitialDataGeneration {
+
+	public void execute() throws UpgradeException;
+}


### PR DESCRIPTION
Hola @csierra,

Tanto desde la comunidad como desde algún equipo de Liferay ha surgido la necesidad de tener que crear una serie de datos en la primera vez que se instala un módulo de Service Builder, ¿qué te parece esta solución? No te fijes en el formateo ni nombres de clases, principalmente en el uso del servicetracker para este caso de uso.

Gracias!