### PR TITLE
OAUTH2-286 Hybrid between our two lambda approaches

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -72,7 +72,7 @@ public interface OAuth2ApplicationLocalService
 			String description, List<String> featuresList, String homePageURL,
 			long iconFileEntryId, String name, String privacyPolicyURL,
 			List<String> redirectURIsList,
-			Function<OAuth2Scope.Builder, OAuth2Scope> builderFunction,
+			Function<OAuth2Scope, OAuth2Scope> builderFunction,
 			ServiceContext serviceContext)
 		throws PortalException;
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -64,6 +65,17 @@ public interface OAuth2ApplicationLocalService
 	 *
 	 * Never modify or reference this interface directly. Always use {@link OAuth2ApplicationLocalServiceUtil} to access the o auth2 application local service. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2ApplicationLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
+	public OAuth2Application addOAuth2Application(
+			long companyId, long userId, String userName,
+			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,
+			String clientId, int clientProfile, String clientSecret,
+			String description, List<String> featuresList, String homePageURL,
+			long iconFileEntryId, String name, String privacyPolicyURL,
+			List<String> redirectURIsList,
+			Function<OAuth2Scope.Builder, OAuth2Scope> builderFunction,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public OAuth2Application addOAuth2Application(
 			long companyId, long userId, String userName,
 			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -53,6 +53,29 @@ public class OAuth2ApplicationLocalServiceUtil {
 				java.util.List<String> featuresList, String homePageURL,
 				long iconFileEntryId, String name, String privacyPolicyURL,
 				java.util.List<String> redirectURIsList,
+				java.util.function.Function<OAuth2Scope.Builder, OAuth2Scope>
+					builderFunction,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addOAuth2Application(
+			companyId, userId, userName, allowedGrantTypesList,
+			clientCredentialUserId, clientId, clientProfile, clientSecret,
+			description, featuresList, homePageURL, iconFileEntryId, name,
+			privacyPolicyURL, redirectURIsList, builderFunction,
+			serviceContext);
+	}
+
+	public static com.liferay.oauth2.provider.model.OAuth2Application
+			addOAuth2Application(
+				long companyId, long userId, String userName,
+				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
+					allowedGrantTypesList,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String name, String privacyPolicyURL,
+				java.util.List<String> redirectURIsList,
 				java.util.List<String> scopeAliasesList,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -53,7 +53,7 @@ public class OAuth2ApplicationLocalServiceUtil {
 				java.util.List<String> featuresList, String homePageURL,
 				long iconFileEntryId, String name, String privacyPolicyURL,
 				java.util.List<String> redirectURIsList,
-				java.util.function.Function<OAuth2Scope.Builder, OAuth2Scope>
+				java.util.function.Function<OAuth2Scope, OAuth2Scope>
 					builderFunction,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -49,7 +49,7 @@ public class OAuth2ApplicationLocalServiceWrapper
 				java.util.List<String> featuresList, String homePageURL,
 				long iconFileEntryId, String name, String privacyPolicyURL,
 				java.util.List<String> redirectURIsList,
-				java.util.function.Function<OAuth2Scope.Builder, OAuth2Scope>
+				java.util.function.Function<OAuth2Scope, OAuth2Scope>
 					builderFunction,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -49,6 +49,30 @@ public class OAuth2ApplicationLocalServiceWrapper
 				java.util.List<String> featuresList, String homePageURL,
 				long iconFileEntryId, String name, String privacyPolicyURL,
 				java.util.List<String> redirectURIsList,
+				java.util.function.Function<OAuth2Scope.Builder, OAuth2Scope>
+					builderFunction,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationLocalService.addOAuth2Application(
+			companyId, userId, userName, allowedGrantTypesList,
+			clientCredentialUserId, clientId, clientProfile, clientSecret,
+			description, featuresList, homePageURL, iconFileEntryId, name,
+			privacyPolicyURL, redirectURIsList, builderFunction,
+			serviceContext);
+	}
+
+	@Override
+	public com.liferay.oauth2.provider.model.OAuth2Application
+			addOAuth2Application(
+				long companyId, long userId, String userName,
+				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
+					allowedGrantTypesList,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String name, String privacyPolicyURL,
+				java.util.List<String> redirectURIsList,
 				java.util.List<String> scopeAliasesList,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -60,6 +61,12 @@ public interface OAuth2ApplicationScopeAliasesLocalService
 	 *
 	 * Never modify or reference this interface directly. Always use {@link OAuth2ApplicationScopeAliasesLocalServiceUtil} to access the o auth2 application scope aliases local service. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2ApplicationScopeAliasesLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
+	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
+			long companyId, long userId, String userName,
+			long oAuth2ApplicationId,
+			Function<OAuth2Scope.Builder, OAuth2Scope> builderFunction)
+		throws PortalException;
+
 	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
 			long companyId, long userId, String userName,
 			long oAuth2ApplicationId, List<String> scopeAliasesList)

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
@@ -64,7 +64,7 @@ public interface OAuth2ApplicationScopeAliasesLocalService
 	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
 			long companyId, long userId, String userName,
 			long oAuth2ApplicationId,
-			Function<OAuth2Scope.Builder, OAuth2Scope> builderFunction)
+			Function<OAuth2Scope, OAuth2Scope> builderFunction)
 		throws PortalException;
 
 	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
@@ -48,6 +48,19 @@ public class OAuth2ApplicationScopeAliasesLocalServiceUtil {
 				addOAuth2ApplicationScopeAliases(
 					long companyId, long userId, String userName,
 					long oAuth2ApplicationId,
+					java.util.function.Function
+						<OAuth2Scope.Builder, OAuth2Scope> builderFunction)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addOAuth2ApplicationScopeAliases(
+			companyId, userId, userName, oAuth2ApplicationId, builderFunction);
+	}
+
+	public static
+		com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases
+				addOAuth2ApplicationScopeAliases(
+					long companyId, long userId, String userName,
+					long oAuth2ApplicationId,
 					java.util.List<String> scopeAliasesList)
 			throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
@@ -48,8 +48,8 @@ public class OAuth2ApplicationScopeAliasesLocalServiceUtil {
 				addOAuth2ApplicationScopeAliases(
 					long companyId, long userId, String userName,
 					long oAuth2ApplicationId,
-					java.util.function.Function
-						<OAuth2Scope.Builder, OAuth2Scope> builderFunction)
+					java.util.function.Function<OAuth2Scope, OAuth2Scope>
+						builderFunction)
 			throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().addOAuth2ApplicationScopeAliases(

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
@@ -45,7 +45,7 @@ public class OAuth2ApplicationScopeAliasesLocalServiceWrapper
 			addOAuth2ApplicationScopeAliases(
 				long companyId, long userId, String userName,
 				long oAuth2ApplicationId,
-				java.util.function.Function<OAuth2Scope.Builder, OAuth2Scope>
+				java.util.function.Function<OAuth2Scope, OAuth2Scope>
 					builderFunction)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
@@ -45,6 +45,21 @@ public class OAuth2ApplicationScopeAliasesLocalServiceWrapper
 			addOAuth2ApplicationScopeAliases(
 				long companyId, long userId, String userName,
 				long oAuth2ApplicationId,
+				java.util.function.Function<OAuth2Scope.Builder, OAuth2Scope>
+					builderFunction)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationScopeAliasesLocalService.
+			addOAuth2ApplicationScopeAliases(
+				companyId, userId, userName, oAuth2ApplicationId,
+				builderFunction);
+	}
+
+	@Override
+	public com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases
+			addOAuth2ApplicationScopeAliases(
+				long companyId, long userId, String userName,
+				long oAuth2ApplicationId,
 				java.util.List<String> scopeAliasesList)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
@@ -21,39 +21,27 @@ import java.util.function.Function;
 /**
  * @author Stian Sigvartsen
  */
-public final class OAuth2Scope {
+public interface OAuth2Scope {
 
-	public interface Builder {
+	public OAuth2Scope forApplication(
+		String applicationName,
+		Function<ScopeAssigner, ScopeAssigner> scopeAssignerFunction);
 
-		public default OAuth2Scope build() {
-			return new OAuth2Scope();
+	public interface ScopeAssigner {
+
+		public default ScopeAssigner assignScope(String scope) {
+			return assignScope(scope, Collections.singletonList(scope));
 		}
 
-		public Builder forApplication(
-			String applicationName,
-			Function<ScopeAssigner, ScopeAssigner> scopeAssignerFunction);
+		public ScopeAssigner assignScope(
+			String scope, List<String> scopeAliases);
 
-		public interface ScopeAssigner {
+		public default ScopeAssigner assignScope(
+			String scope, String scopeAlias) {
 
-			public default ScopeAssigner assignScope(String scope) {
-				return assignScope(scope, Collections.singletonList(scope));
-			}
-
-			public ScopeAssigner assignScope(
-				String scope, List<String> scopeAliases);
-
-			public default ScopeAssigner assignScope(
-				String scope, String scopeAlias) {
-
-				return assignScope(
-					scope, Collections.singletonList(scopeAlias));
-			}
-
+			return assignScope(scope, Collections.singletonList(scopeAlias));
 		}
 
-	}
-
-	private OAuth2Scope() {
 	}
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * @author Stian Sigvartsen
+ */
+public final class OAuth2Scope {
+
+	public interface Builder {
+
+		public default OAuth2Scope build() {
+			return new OAuth2Scope();
+		}
+
+		public Builder forApplication(
+			String applicationName,
+			Function<ScopeAssigner, ScopeAssigner> scopeAssignerFunction);
+
+		public interface ScopeAssigner {
+
+			public default ScopeAssigner assignScope(String scope) {
+				return assignScope(scope, Collections.singletonList(scope));
+			}
+
+			public ScopeAssigner assignScope(
+				String scope, List<String> scopeAliases);
+
+			public default ScopeAssigner assignScope(
+				String scope, String scopeAlias) {
+
+				return assignScope(
+					scope, Collections.singletonList(scopeAlias));
+			}
+
+		}
+
+	}
+
+	private OAuth2Scope() {
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.2
+version 1.4.0

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -36,6 +36,7 @@ import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2Scope;
 import com.liferay.oauth2.provider.service.base.OAuth2ApplicationLocalServiceBaseImpl;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.portal.aop.AopService;
@@ -78,6 +79,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -93,6 +95,89 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class OAuth2ApplicationLocalServiceImpl
 	extends OAuth2ApplicationLocalServiceBaseImpl {
+
+	@Override
+	public OAuth2Application addOAuth2Application(
+			long companyId, long userId, String userName,
+			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,
+			String clientId, int clientProfile, String clientSecret,
+			String description, List<String> featuresList, String homePageURL,
+			long iconFileEntryId, String name, String privacyPolicyURL,
+			List<String> redirectURIsList,
+			Function<OAuth2Scope.Builder, OAuth2Scope> builderFunction,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		if (allowedGrantTypesList == null) {
+			allowedGrantTypesList = new ArrayList<>();
+		}
+
+		if (Validator.isBlank(clientId)) {
+			clientId = OAuth2SecureRandomGenerator.generateClientId();
+		}
+		else {
+			clientId = StringUtil.trim(clientId);
+		}
+
+		homePageURL = StringUtil.trim(homePageURL);
+		name = StringUtil.trim(name);
+		privacyPolicyURL = StringUtil.trim(privacyPolicyURL);
+
+		if (redirectURIsList == null) {
+			redirectURIsList = new ArrayList<>();
+		}
+
+		validate(
+			companyId, allowedGrantTypesList, clientId, clientProfile,
+			clientSecret, homePageURL, name, privacyPolicyURL,
+			redirectURIsList);
+
+		long oAuth2ApplicationId = counterLocalService.increment(
+			OAuth2Application.class.getName());
+
+		User user = _userLocalService.getUser(clientCredentialUserId);
+
+		OAuth2Application oAuth2Application =
+			oAuth2ApplicationPersistence.create(oAuth2ApplicationId);
+
+		oAuth2Application.setCompanyId(companyId);
+		oAuth2Application.setUserId(userId);
+		oAuth2Application.setUserName(userName);
+		oAuth2Application.setCreateDate(new Date());
+		oAuth2Application.setModifiedDate(new Date());
+		oAuth2Application.setAllowedGrantTypesList(allowedGrantTypesList);
+		oAuth2Application.setClientCredentialUserId(user.getUserId());
+		oAuth2Application.setClientCredentialUserName(user.getScreenName());
+		oAuth2Application.setClientId(clientId);
+		oAuth2Application.setClientProfile(clientProfile);
+		oAuth2Application.setClientSecret(clientSecret);
+		oAuth2Application.setDescription(description);
+		oAuth2Application.setFeaturesList(featuresList);
+		oAuth2Application.setHomePageURL(homePageURL);
+		oAuth2Application.setIconFileEntryId(iconFileEntryId);
+		oAuth2Application.setName(name);
+		oAuth2Application.setPrivacyPolicyURL(privacyPolicyURL);
+		oAuth2Application.setRedirectURIsList(redirectURIsList);
+
+		if (builderFunction != null) {
+			OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
+				_oAuth2ApplicationScopeAliasesLocalService.
+					addOAuth2ApplicationScopeAliases(
+						companyId, userId, userName, oAuth2ApplicationId,
+						builderFunction);
+
+			oAuth2Application.setOAuth2ApplicationScopeAliasesId(
+				oAuth2ApplicationScopeAliases.
+					getOAuth2ApplicationScopeAliasesId());
+		}
+
+		resourceLocalService.addResources(
+			oAuth2Application.getCompanyId(), 0, oAuth2Application.getUserId(),
+			OAuth2Application.class.getName(),
+			oAuth2Application.getOAuth2ApplicationId(), false, false, false);
+
+		return oAuth2ApplicationPersistence.update(oAuth2Application);
+	}
 
 	@Override
 	public OAuth2Application addOAuth2Application(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -104,7 +104,7 @@ public class OAuth2ApplicationLocalServiceImpl
 			String description, List<String> featuresList, String homePageURL,
 			long iconFileEntryId, String name, String privacyPolicyURL,
 			List<String> redirectURIsList,
-			Function<OAuth2Scope.Builder, OAuth2Scope> builderFunction,
+			Function<OAuth2Scope, OAuth2Scope> builderFunction,
 			ServiceContext serviceContext)
 		throws PortalException {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
@@ -91,7 +91,7 @@ public class FragmentRendererPortalInstanceLifecycleListener
 			"liferay-json-web-services", "com.liferay.oauth2.provider.jsonws",
 			"everything.read",
 			Collections.singletonList(
-				"liferay-json-web-services.everything.read"));
+				"liferay-json-web-services.fragments.everything.read"));
 
 		oAuth2Application.setOAuth2ApplicationScopeAliasesId(
 			oAuth2ApplicationScopeAliases.getOAuth2ApplicationScopeAliasesId());

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
@@ -17,7 +17,7 @@ package com.liferay.oauth2.provider.shortcut.internal.instance.lifecycle;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
-import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
+import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
@@ -73,38 +73,21 @@ public class FragmentRendererPortalInstanceLifecycleListener
 			},
 			user.getUserId(), _clientId, ClientProfile.NATIVE_APPLICATION.id(),
 			StringPool.BLANK, null, null, null, 0, _applicationName, null,
-			Collections.emptyList(), Collections.emptyList(),
+			Collections.emptyList(),
+			builder -> builder.forApplication(
+				"liferay-json-web-services",
+				scopeAssigner -> scopeAssigner.assignScope(
+					"everything.read",
+					"liferay-json-web-services.fragments.everything.read")
+			).build(),
 			new ServiceContext());
-
-		OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
-			_oAuth2ApplicationScopeAliasesLocalService.
-				addOAuth2ApplicationScopeAliases(
-					oAuth2Application.getCompanyId(),
-					oAuth2Application.getUserId(),
-					oAuth2Application.getUserName(),
-					oAuth2Application.getOAuth2ApplicationId(),
-					Collections.emptyList());
-
-		_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
-			oAuth2Application.getCompanyId(),
-			oAuth2ApplicationScopeAliases.getOAuth2ApplicationScopeAliasesId(),
-			"liferay-json-web-services", "com.liferay.oauth2.provider.jsonws",
-			"everything.read",
-			Collections.singletonList(
-				"liferay-json-web-services.fragments.everything.read"));
-
-		oAuth2Application.setOAuth2ApplicationScopeAliasesId(
-			oAuth2ApplicationScopeAliases.getOAuth2ApplicationScopeAliasesId());
-
-		_oAuth2ApplicationLocalService.updateOAuth2Application(
-			oAuth2Application);
 	}
 
 	@Activate
 	protected void activate(Map<String, Object> properties) {
+		_clientId = GetterUtil.getString(properties.get("clientId"));
 		_applicationName = GetterUtil.getString(
 			properties.get("applicationName"));
-		_clientId = GetterUtil.getString(properties.get("clientId"));
 	}
 
 	private String _applicationName = "Fragment Renderer";
@@ -119,6 +102,9 @@ public class FragmentRendererPortalInstanceLifecycleListener
 
 	@Reference
 	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
+
+	@Reference
+	private ScopeLocator _scopeLocator;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
@@ -63,7 +63,7 @@ public class FragmentRendererPortalInstanceLifecycleListener
 
 		User user = _userLocalService.getDefaultUser(company.getCompanyId());
 
-		oAuth2Application = _oAuth2ApplicationLocalService.addOAuth2Application(
+		_oAuth2ApplicationLocalService.addOAuth2Application(
 			company.getCompanyId(), user.getUserId(), user.getScreenName(),
 			new ArrayList<GrantType>() {
 				{
@@ -74,12 +74,11 @@ public class FragmentRendererPortalInstanceLifecycleListener
 			user.getUserId(), _clientId, ClientProfile.NATIVE_APPLICATION.id(),
 			StringPool.BLANK, null, null, null, 0, _applicationName, null,
 			Collections.emptyList(),
-			builder -> builder.forApplication(
+			oAuth2Scope -> oAuth2Scope.forApplication(
 				"liferay-json-web-services",
 				scopeAssigner -> scopeAssigner.assignScope(
 					"everything.read",
-					"liferay-json-web-services.fragments.everything.read")
-			).build(),
+					"liferay-json-web-services.fragments.everything.read")),
 			new ServiceContext());
 	}
 


### PR DESCRIPTION
Hi Carlos. As discussed I think a hybrid between the lambda approaches would be good, to achieve the following...

1) Client code provides a Function<ScopeAssigner,ScopeAssigner> to enable assignment of multiple scopes & aliases (a shortcoming of one of our approaches)
2) Use a termination type instead of a concrete type. This avoids the need to call build(). Because we don't have such a method, I think the types should use the word "Builder". A Function<OAuth2Scope,OAuth2Scope> seems more sensible, especially considers you may not want any scopes assigned and so you can provide Function.identity()

Thoughts?