### PR TITLE
OAUTH2-286 Provide bundle symbolic name statically

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -64,6 +65,17 @@ public interface OAuth2ApplicationLocalService
 	 *
 	 * Never modify or reference this interface directly. Always use {@link OAuth2ApplicationLocalServiceUtil} to access the o auth2 application local service. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2ApplicationLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
+	public OAuth2Application addOAuth2Application(
+			long companyId, long userId, String userName,
+			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,
+			String clientId, int clientProfile, String clientSecret,
+			String description, List<String> featuresList, String homePageURL,
+			long iconFileEntryId, String name, String privacyPolicyURL,
+			List<String> redirectURIsList,
+			Consumer<OAuth2Scope.Builder> builderConsumer,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public OAuth2Application addOAuth2Application(
 			long companyId, long userId, String userName,
 			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -53,6 +53,29 @@ public class OAuth2ApplicationLocalServiceUtil {
 				java.util.List<String> featuresList, String homePageURL,
 				long iconFileEntryId, String name, String privacyPolicyURL,
 				java.util.List<String> redirectURIsList,
+				java.util.function.Consumer<OAuth2Scope.Builder>
+					builderConsumer,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addOAuth2Application(
+			companyId, userId, userName, allowedGrantTypesList,
+			clientCredentialUserId, clientId, clientProfile, clientSecret,
+			description, featuresList, homePageURL, iconFileEntryId, name,
+			privacyPolicyURL, redirectURIsList, builderConsumer,
+			serviceContext);
+	}
+
+	public static com.liferay.oauth2.provider.model.OAuth2Application
+			addOAuth2Application(
+				long companyId, long userId, String userName,
+				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
+					allowedGrantTypesList,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String name, String privacyPolicyURL,
+				java.util.List<String> redirectURIsList,
 				java.util.List<String> scopeAliasesList,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -49,6 +49,30 @@ public class OAuth2ApplicationLocalServiceWrapper
 				java.util.List<String> featuresList, String homePageURL,
 				long iconFileEntryId, String name, String privacyPolicyURL,
 				java.util.List<String> redirectURIsList,
+				java.util.function.Consumer<OAuth2Scope.Builder>
+					builderConsumer,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationLocalService.addOAuth2Application(
+			companyId, userId, userName, allowedGrantTypesList,
+			clientCredentialUserId, clientId, clientProfile, clientSecret,
+			description, featuresList, homePageURL, iconFileEntryId, name,
+			privacyPolicyURL, redirectURIsList, builderConsumer,
+			serviceContext);
+	}
+
+	@Override
+	public com.liferay.oauth2.provider.model.OAuth2Application
+			addOAuth2Application(
+				long companyId, long userId, String userName,
+				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
+					allowedGrantTypesList,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String name, String privacyPolicyURL,
+				java.util.List<String> redirectURIsList,
 				java.util.List<String> scopeAliasesList,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalService.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -60,6 +61,12 @@ public interface OAuth2ApplicationScopeAliasesLocalService
 	 *
 	 * Never modify or reference this interface directly. Always use {@link OAuth2ApplicationScopeAliasesLocalServiceUtil} to access the o auth2 application scope aliases local service. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2ApplicationScopeAliasesLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
+	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
+			long companyId, long userId, String userName,
+			long oAuth2ApplicationId,
+			Consumer<OAuth2Scope.Builder> builderConsumer)
+		throws PortalException;
+
 	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
 			long companyId, long userId, String userName,
 			long oAuth2ApplicationId, List<String> scopeAliasesList)

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceUtil.java
@@ -48,6 +48,19 @@ public class OAuth2ApplicationScopeAliasesLocalServiceUtil {
 				addOAuth2ApplicationScopeAliases(
 					long companyId, long userId, String userName,
 					long oAuth2ApplicationId,
+					java.util.function.Consumer<OAuth2Scope.Builder>
+						builderConsumer)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addOAuth2ApplicationScopeAliases(
+			companyId, userId, userName, oAuth2ApplicationId, builderConsumer);
+	}
+
+	public static
+		com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases
+				addOAuth2ApplicationScopeAliases(
+					long companyId, long userId, String userName,
+					long oAuth2ApplicationId,
 					java.util.List<String> scopeAliasesList)
 			throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationScopeAliasesLocalServiceWrapper.java
@@ -45,6 +45,21 @@ public class OAuth2ApplicationScopeAliasesLocalServiceWrapper
 			addOAuth2ApplicationScopeAliases(
 				long companyId, long userId, String userName,
 				long oAuth2ApplicationId,
+				java.util.function.Consumer<OAuth2Scope.Builder>
+					builderConsumer)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationScopeAliasesLocalService.
+			addOAuth2ApplicationScopeAliases(
+				companyId, userId, userName, oAuth2ApplicationId,
+				builderConsumer);
+	}
+
+	@Override
+	public com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases
+			addOAuth2ApplicationScopeAliases(
+				long companyId, long userId, String userName,
+				long oAuth2ApplicationId,
 				java.util.List<String> scopeAliasesList)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
@@ -27,7 +27,7 @@ public interface OAuth2Scope {
 	public interface Builder {
 
 		public void forApplication(
-			String applicationName,
+			String applicationName, String bundleSymbolicName,
 			Consumer<ApplicationScopeAssigner>
 				applicationScopeAssignerConsumer);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2Scope.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.service;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/**
+ * @author Stian Sigvartsen
+ * @author Carlos Sierra
+ */
+public interface OAuth2Scope {
+
+	public interface Builder {
+
+		public void forApplication(
+			String applicationName,
+			Consumer<ApplicationScopeAssigner>
+				applicationScopeAssignerConsumer);
+
+		public interface ApplicationScope {
+
+			public void mapToScopeAlias(Collection<String> scopeAliases);
+
+			public default void mapToScopeAlias(String... scopeAlias) {
+				mapToScopeAlias(Arrays.asList(scopeAlias));
+			}
+
+		}
+
+		public interface ApplicationScopeAssigner {
+
+			public ApplicationScope assignScope(Collection<String> scopes);
+
+			public default ApplicationScope assignScope(String... scope) {
+				return assignScope(Arrays.asList(scope));
+			}
+
+		}
+
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.2
+version 1.4.0

--- a/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
@@ -20,4 +20,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":core:registry-api")
+
+	testCompile group: "junit", name: "junit", version: "4.12"
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -36,6 +36,7 @@ import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2Scope;
 import com.liferay.oauth2.provider.service.base.OAuth2ApplicationLocalServiceBaseImpl;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.portal.aop.AopService;
@@ -78,6 +79,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -93,6 +95,89 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class OAuth2ApplicationLocalServiceImpl
 	extends OAuth2ApplicationLocalServiceBaseImpl {
+
+	@Override
+	public OAuth2Application addOAuth2Application(
+			long companyId, long userId, String userName,
+			List<GrantType> allowedGrantTypesList, long clientCredentialUserId,
+			String clientId, int clientProfile, String clientSecret,
+			String description, List<String> featuresList, String homePageURL,
+			long iconFileEntryId, String name, String privacyPolicyURL,
+			List<String> redirectURIsList,
+			Consumer<OAuth2Scope.Builder> builderConsumer,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		if (allowedGrantTypesList == null) {
+			allowedGrantTypesList = new ArrayList<>();
+		}
+
+		if (Validator.isBlank(clientId)) {
+			clientId = OAuth2SecureRandomGenerator.generateClientId();
+		}
+		else {
+			clientId = StringUtil.trim(clientId);
+		}
+
+		homePageURL = StringUtil.trim(homePageURL);
+		name = StringUtil.trim(name);
+		privacyPolicyURL = StringUtil.trim(privacyPolicyURL);
+
+		if (redirectURIsList == null) {
+			redirectURIsList = new ArrayList<>();
+		}
+
+		validate(
+			companyId, allowedGrantTypesList, clientId, clientProfile,
+			clientSecret, homePageURL, name, privacyPolicyURL,
+			redirectURIsList);
+
+		long oAuth2ApplicationId = counterLocalService.increment(
+			OAuth2Application.class.getName());
+
+		User user = _userLocalService.getUser(clientCredentialUserId);
+
+		OAuth2Application oAuth2Application =
+			oAuth2ApplicationPersistence.create(oAuth2ApplicationId);
+
+		oAuth2Application.setCompanyId(companyId);
+		oAuth2Application.setUserId(userId);
+		oAuth2Application.setUserName(userName);
+		oAuth2Application.setCreateDate(new Date());
+		oAuth2Application.setModifiedDate(new Date());
+		oAuth2Application.setAllowedGrantTypesList(allowedGrantTypesList);
+		oAuth2Application.setClientCredentialUserId(user.getUserId());
+		oAuth2Application.setClientCredentialUserName(user.getScreenName());
+		oAuth2Application.setClientId(clientId);
+		oAuth2Application.setClientProfile(clientProfile);
+		oAuth2Application.setClientSecret(clientSecret);
+		oAuth2Application.setDescription(description);
+		oAuth2Application.setFeaturesList(featuresList);
+		oAuth2Application.setHomePageURL(homePageURL);
+		oAuth2Application.setIconFileEntryId(iconFileEntryId);
+		oAuth2Application.setName(name);
+		oAuth2Application.setPrivacyPolicyURL(privacyPolicyURL);
+		oAuth2Application.setRedirectURIsList(redirectURIsList);
+
+		if (builderConsumer != null) {
+			OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
+				_oAuth2ApplicationScopeAliasesLocalService.
+					addOAuth2ApplicationScopeAliases(
+						companyId, userId, userName, oAuth2ApplicationId,
+						builderConsumer);
+
+			oAuth2Application.setOAuth2ApplicationScopeAliasesId(
+				oAuth2ApplicationScopeAliases.
+					getOAuth2ApplicationScopeAliasesId());
+		}
+
+		resourceLocalService.addResources(
+			oAuth2Application.getCompanyId(), 0, oAuth2Application.getUserId(),
+			OAuth2Application.class.getName(),
+			oAuth2Application.getOAuth2ApplicationId(), false, false, false);
+
+		return oAuth2ApplicationPersistence.update(oAuth2Application);
+	}
 
 	@Override
 	public OAuth2Application addOAuth2Application(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -95,8 +95,8 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 			_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
 				companyId, oAuth2ApplicationScopeAliasesId,
-				scopeNamespace._applicationName,
-				scopeNamespace._bundleSymbolicName, key.getValue(),
+				scopeNamespace.applicationName,
+				scopeNamespace.bundleSymbolicName, key.getValue(),
 				entry.getValue());
 		}
 
@@ -304,8 +304,8 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 		public ScopeNamespace(
 			String applicationName, String bundleSymbolicName) {
 
-			_applicationName = applicationName;
-			_bundleSymbolicName = bundleSymbolicName;
+			this.applicationName = applicationName;
+			this.bundleSymbolicName = bundleSymbolicName;
 		}
 
 		@Override
@@ -313,9 +313,9 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 			ScopeNamespace scopeNamespace = (ScopeNamespace)obj;
 
 			if (Objects.equals(
-					_applicationName, scopeNamespace._applicationName) &&
+					applicationName, scopeNamespace.applicationName) &&
 				Objects.equals(
-					_bundleSymbolicName, scopeNamespace._bundleSymbolicName)) {
+					bundleSymbolicName, scopeNamespace.bundleSymbolicName)) {
 
 				return true;
 			}
@@ -325,11 +325,11 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(_applicationName, _bundleSymbolicName);
+			return Objects.hash(applicationName, bundleSymbolicName);
 		}
 
-		private final String _applicationName;
-		private final String _bundleSymbolicName;
+		protected final String applicationName;
+		protected final String bundleSymbolicName;
 
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
 import com.liferay.oauth2.provider.model.OAuth2ScopeGrant;
 import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
+import com.liferay.oauth2.provider.service.OAuth2Scope;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.oauth2.provider.service.base.OAuth2ApplicationScopeAliasesLocalServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
@@ -27,6 +28,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -36,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -52,6 +55,24 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 	extends OAuth2ApplicationScopeAliasesLocalServiceBaseImpl {
+
+	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
+			long companyId, long userId, String userName,
+			long oAuth2ApplicationId,
+			Consumer<OAuth2Scope.Builder> builderConsumer)
+		throws PortalException {
+
+		Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			simpleEntryScopeAliases = new HashMap<>();
+
+		builderConsumer.accept(
+			new OAuth2ScopeBuilderImpl(simpleEntryScopeAliases));
+
+		return _addOAuth2ApplicationScopeAliases(
+			companyId, userId, userName, oAuth2ApplicationId,
+			_getLiferayOAuth2ScopesScopeAliases(
+				companyId, simpleEntryScopeAliases));
+	}
 
 	@Override
 	public OAuth2ApplicationScopeAliases addOAuth2ApplicationScopeAliases(
@@ -202,6 +223,73 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 		}
 	}
 
+	protected static class OAuth2ScopeBuilderImpl
+		implements OAuth2Scope.Builder,
+				   OAuth2Scope.Builder.ApplicationScopeAssigner,
+				   OAuth2Scope.Builder.ApplicationScope {
+
+		public OAuth2ScopeBuilderImpl(
+			Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+				simpleEntryScopeAliases) {
+
+			_simpleEntryScopeAliases = simpleEntryScopeAliases;
+			_scopes = new ArrayList<>();
+			_scopeAliases = new ArrayList<>();
+		}
+
+		public ApplicationScope assignScope(Collection<String> scope) {
+			_flushScopes();
+
+			_scopes.addAll(scope);
+
+			return this;
+		}
+
+		@Override
+		public void forApplication(
+			String applicationName,
+			Consumer<ApplicationScopeAssigner>
+				applicationScopeAssignerConsumer) {
+
+			_applicationName = applicationName;
+
+			applicationScopeAssignerConsumer.accept(this);
+
+			_flushScopes();
+		}
+
+		@Override
+		public void mapToScopeAlias(Collection<String> scopeAliases) {
+			_scopeAliases = scopeAliases;
+		}
+
+		private void _flushScopes() {
+			for (String scope : _scopes) {
+				List<String> scopeAliasList =
+					_simpleEntryScopeAliases.computeIfAbsent(
+						new AbstractMap.SimpleEntry<>(_applicationName, scope),
+						s -> new ArrayList<>());
+
+				for (String scopeAlias : _scopeAliases) {
+					if (!scopeAliasList.contains(scopeAlias)) {
+						scopeAliasList.add(scopeAlias);
+					}
+				}
+			}
+
+			_scopes.clear();
+
+			_scopeAliases = _scopes;
+		}
+
+		private String _applicationName;
+		private Collection<String> _scopeAliases;
+		private final Collection<String> _scopes;
+		private final Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			_simpleEntryScopeAliases;
+
+	}
+
 	private OAuth2ApplicationScopeAliases _addOAuth2ApplicationScopeAliases(
 			long companyId, long userId, String userName,
 			long oAuth2ApplicationId,
@@ -255,6 +343,24 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 		}
 
 		return liferayOAuth2ScopesScopeAliases;
+	}
+
+	private Map<LiferayOAuth2Scope, List<String>>
+		_getLiferayOAuth2ScopesScopeAliases(
+			long companyId,
+			Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+				simpleEntryScopeAliases) {
+
+		Map<LiferayOAuth2Scope, List<String>> liferayOAuth2ScopeListMap =
+			new HashMap<>();
+
+		simpleEntryScopeAliases.forEach(
+			(simpleEntry, scopeAliases) -> liferayOAuth2ScopeListMap.put(
+				_scopeLocator.getLiferayOAuth2Scope(
+					companyId, simpleEntry.getKey(), simpleEntry.getValue()),
+				scopeAliases));
+
+		return liferayOAuth2ScopeListMap;
 	}
 
 	private List<String> _getScopeAliasesList(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -262,14 +262,13 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 
 		Stream<OAuth2ScopeGrant> stream = oAuth2ScopeGrants.stream();
 
-		Set<String> scopeAliases = stream.flatMap(
+		return stream.flatMap(
 			oa2sg -> oa2sg.getScopeAliasesList(
 			).stream()
+		).distinct(
 		).collect(
-			Collectors.toSet()
+			Collectors.toList()
 		);
-
-		return new ArrayList<>(scopeAliases);
 	}
 
 	private boolean _hasUpToDateScopeGrants(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/test/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeBuilderImplTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/test/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeBuilderImplTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.not;
 
 import com.liferay.oauth2.provider.service.OAuth2Scope;
+import com.liferay.oauth2.provider.service.impl.OAuth2ApplicationScopeAliasesLocalServiceImpl.ScopeNamespace;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
@@ -57,11 +58,11 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 
 		String scopeAlias = "everything";
 
-		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
-			simpeEntryScopeAliases = _exerciseBuilder(
+		Map<Map.Entry<String, String>, Set<String>> simpeEntryScopeAliases =
+			_exerciseBuilder(
 				builder -> {
 					builder.forApplication(
-						applicationName1,
+						applicationName1, _TEST_BUNDLE_SYMBOLIC_NAME,
 						applicationScopeAssigner ->
 							applicationScopeAssigner.assignScope(
 								scopes
@@ -71,7 +72,7 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 							));
 
 					builder.forApplication(
-						applicationName2,
+						applicationName2, _TEST_BUNDLE_SYMBOLIC_NAME,
 						applicationScopeAssigner ->
 							applicationScopeAssigner.assignScope(
 								scopes
@@ -103,11 +104,11 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 				"Test.Application2", Sets.newHashSet("application2.everything")
 			).build();
 
-		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
-			simpeEntryScopeAliases = _exerciseBuilder(
+		Map<Map.Entry<String, String>, Set<String>> simpeEntryScopeAliases =
+			_exerciseBuilder(
 				builder -> applicationScopeAlias.forEach(
 					(applicationName, scopeAliases) -> builder.forApplication(
-						applicationName,
+						applicationName, _TEST_BUNDLE_SYMBOLIC_NAME,
 						applicationScopeAssigner ->
 							applicationScopeAssigner.assignScope(
 								scopes
@@ -131,10 +132,10 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 
 		String scopeAlias = "everything";
 
-		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
-			simpeEntryScopeAliases = _exerciseBuilder(
+		Map<Map.Entry<String, String>, Set<String>> simpeEntryScopeAliases =
+			_exerciseBuilder(
 				builder -> builder.forApplication(
-					applicationName,
+					applicationName, _TEST_BUNDLE_SYMBOLIC_NAME,
 					applicationScopeAssigner ->
 						applicationScopeAssigner.assignScope(
 							scopes
@@ -159,10 +160,10 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 
 		Collection<String> scopeAlias = Collections.singleton("everything");
 
-		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
-			simpeEntryScopeAliases = _exerciseBuilder(
+		Map<Map.Entry<String, String>, Set<String>> simpeEntryScopeAliases =
+			_exerciseBuilder(
 				builder -> builder.forApplication(
-					applicationName,
+					applicationName, _TEST_BUNDLE_SYMBOLIC_NAME,
 					applicationScopeAssigner -> {
 						applicationScopeAssigner.assignScope(
 							"everything.read"
@@ -201,10 +202,10 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 
 		// Test assigning scopes using Collection
 
-		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
-			simpeEntryScopeAliases1 = _exerciseBuilder(
+		Map<Map.Entry<String, String>, Set<String>> simpeEntryScopeAliases1 =
+			_exerciseBuilder(
 				builder -> builder.forApplication(
-					applicationName,
+					applicationName, _TEST_BUNDLE_SYMBOLIC_NAME,
 					applicationScopeAssigner ->
 						applicationScopeAssigner.assignScope(scopes)));
 
@@ -215,10 +216,10 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 
 		// Repeat using VarArgs
 
-		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
-			simpeEntryScopeAliases2 = _exerciseBuilder(
+		Map<Map.Entry<String, String>, Set<String>> simpeEntryScopeAliases2 =
+			_exerciseBuilder(
 				builder -> builder.forApplication(
-					applicationName,
+					applicationName, _TEST_BUNDLE_SYMBOLIC_NAME,
 					applicationScopeAssigner ->
 						applicationScopeAssigner.assignScope(scopesArray)));
 
@@ -228,11 +229,11 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 			simpeEntryScopeAliases2.toString(), simpeEntryScopeAliases1.size(),
 			simpeEntryScopeAliases2.size());
 
-		Set<Map.Entry<AbstractMap.SimpleEntry<String, String>, Set<String>>>
-			entrySet = simpeEntryScopeAliases1.entrySet();
+		Set<Map.Entry<Map.Entry<String, String>, Set<String>>> entrySet =
+			simpeEntryScopeAliases1.entrySet();
 
-		Stream<Map.Entry<AbstractMap.SimpleEntry<String, String>, Set<String>>>
-			stream = entrySet.stream();
+		Stream<Map.Entry<Map.Entry<String, String>, Set<String>>> stream =
+			entrySet.stream();
 
 		Assert.assertTrue(
 			stream.allMatch(
@@ -245,7 +246,7 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 
 		simpeEntryScopeAliases1 = _exerciseBuilder(
 			builder -> builder.forApplication(
-				applicationName,
+				applicationName, _TEST_BUNDLE_SYMBOLIC_NAME,
 				applicationScopeAssigner -> {
 					applicationScopeAssigner.assignScope(scopesArray[0]);
 					applicationScopeAssigner.assignScope(scopesArray[1]);
@@ -262,10 +263,10 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 		return applicationName + StringPool.PERIOD + scope;
 	}
 
-	private Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
-		_exerciseBuilder(Consumer<OAuth2Scope.Builder> builderConsumer) {
+	private Map<Map.Entry<String, String>, Set<String>> _exerciseBuilder(
+		Consumer<OAuth2Scope.Builder> builderConsumer) {
 
-		Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+		Map<Map.Entry<ScopeNamespace, String>, List<String>>
 			simpleEntryScopeAliases = new HashMap<>();
 
 		OAuth2Scope.Builder builder =
@@ -274,14 +275,23 @@ public class OAuth2ScopeBuilderImplTest extends PowerMockito {
 
 		builderConsumer.accept(builder);
 
-		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
-			simpleEntryScopeAliasesSet = new HashMap<>();
+		Map<Map.Entry<String, String>, Set<String>> simpleEntryScopeAliasesSet =
+			new HashMap<>();
 
 		simpleEntryScopeAliases.forEach(
-			(key, value) -> simpleEntryScopeAliasesSet.put(
-				key, new HashSet<>(value)));
+			(key, value) -> {
+				ScopeNamespace scopeNamespace = key.getKey();
+
+				simpleEntryScopeAliasesSet.put(
+					new AbstractMap.SimpleEntry<String, String>(
+						scopeNamespace.applicationName, key.getValue()),
+					new HashSet<>(value));
+			});
 
 		return simpleEntryScopeAliasesSet;
 	}
+
+	private static final String _TEST_BUNDLE_SYMBOLIC_NAME =
+		"test.bundle.symbolic.name";
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/test/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeBuilderImplTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/test/java/com/liferay/oauth2/provider/service/impl/OAuth2ScopeBuilderImplTest.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.service.impl;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
+
+import com.liferay.oauth2.provider.service.OAuth2Scope;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.apache.commons.compress.utils.Sets;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author Stian Sigvartsen
+ */
+@RunWith(PowerMockRunner.class)
+public class OAuth2ScopeBuilderImplTest extends PowerMockito {
+
+	@Test
+	public void testApplicationIsolation() {
+		String applicationName1 = "Test.Application1";
+		String applicationName2 = "Test.Application2";
+
+		String[] scopes = {"everything.read", "everything.write"};
+
+		String scopeAlias = "everything";
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases = _exerciseBuilder(
+				builder -> {
+					builder.forApplication(
+						applicationName1,
+						applicationScopeAssigner ->
+							applicationScopeAssigner.assignScope(
+								scopes
+							).mapToScopeAlias(
+								_getApplicationScopeAlias(
+									applicationName1, scopeAlias)
+							));
+
+					builder.forApplication(
+						applicationName2,
+						applicationScopeAssigner ->
+							applicationScopeAssigner.assignScope(
+								scopes
+							).mapToScopeAlias(
+								_getApplicationScopeAlias(
+									applicationName2, scopeAlias)
+							));
+				});
+
+		simpeEntryScopeAliases.forEach(
+			(key, value) -> {
+				Assert.assertThat(value, not(hasItems(scopes)));
+				Assert.assertEquals(1, value.size());
+				Assert.assertThat(
+					value,
+					hasItems(
+						_getApplicationScopeAlias(key.getKey(), scopeAlias)));
+			});
+	}
+
+	@Test
+	public void testApplicationIsolationWithScopeAliases() {
+		String[] scopes = {"everything.read", "everything.write"};
+
+		Map<String, Set<String>> applicationScopeAlias =
+			HashMapBuilder.<String, Set<String>>put(
+				"Test.Application1", Sets.newHashSet("application1.everything")
+			).put(
+				"Test.Application2", Sets.newHashSet("application2.everything")
+			).build();
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases = _exerciseBuilder(
+				builder -> applicationScopeAlias.forEach(
+					(applicationName, scopeAliases) -> builder.forApplication(
+						applicationName,
+						applicationScopeAssigner ->
+							applicationScopeAssigner.assignScope(
+								scopes
+							).mapToScopeAlias(
+								scopeAliases
+							))));
+
+		simpeEntryScopeAliases.forEach(
+			(key, value) -> {
+				Assert.assertThat(value, not(hasItems(scopes)));
+				Assert.assertEquals(
+					value, applicationScopeAlias.get(key.getKey()));
+			});
+	}
+
+	@Test
+	public void testMapToScopeAlias() {
+		String applicationName = "Test.Application";
+
+		String[] scopes = {"everything.read", "everything.write"};
+
+		String scopeAlias = "everything";
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases = _exerciseBuilder(
+				builder -> builder.forApplication(
+					applicationName,
+					applicationScopeAssigner ->
+						applicationScopeAssigner.assignScope(
+							scopes
+						).mapToScopeAlias(
+							scopeAlias
+						)));
+
+		simpeEntryScopeAliases.forEach(
+			(key, value) -> {
+				Assert.assertThat(value, not(hasItems(scopes)));
+				Assert.assertEquals(1, value.size());
+				Assert.assertThat(value, hasItems(scopeAlias));
+			});
+	}
+
+	@Test
+	public void testMultipleSeparateAssignmentsToSameScopeAlias() {
+		String applicationName = "Test.Application";
+
+		Set<String> scopes = Sets.newHashSet(
+			"everything.read", "everything.write");
+
+		Collection<String> scopeAlias = Collections.singleton("everything");
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases = _exerciseBuilder(
+				builder -> builder.forApplication(
+					applicationName,
+					applicationScopeAssigner -> {
+						applicationScopeAssigner.assignScope(
+							"everything.read"
+						).mapToScopeAlias(
+							scopeAlias
+						);
+
+						applicationScopeAssigner.assignScope(
+							"everything.write"
+						).mapToScopeAlias(
+							scopeAlias
+						);
+					}));
+
+		Assert.assertEquals(
+			simpeEntryScopeAliases.toString(), 2,
+			simpeEntryScopeAliases.size());
+
+		simpeEntryScopeAliases.forEach(
+			(key, value) -> {
+				Assert.assertEquals(scopeAlias, value);
+
+				scopes.remove(key.getValue());
+			});
+
+		Assert.assertEquals(scopes.toString(), 0, scopes.size());
+	}
+
+	@Test
+	public void testNoSpecifiedScopeAlias() {
+		String applicationName = "Test.Application";
+
+		String[] scopesArray = {"everything.read", "everything.write"};
+
+		Set<String> scopes = Sets.newHashSet(scopesArray);
+
+		// Test assigning scopes using Collection
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases1 = _exerciseBuilder(
+				builder -> builder.forApplication(
+					applicationName,
+					applicationScopeAssigner ->
+						applicationScopeAssigner.assignScope(scopes)));
+
+		// Test that the resulting scope aliases all map to all scopes
+
+		simpeEntryScopeAliases1.forEach(
+			(key, value) -> Assert.assertEquals(value, scopes));
+
+		// Repeat using VarArgs
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpeEntryScopeAliases2 = _exerciseBuilder(
+				builder -> builder.forApplication(
+					applicationName,
+					applicationScopeAssigner ->
+						applicationScopeAssigner.assignScope(scopesArray)));
+
+		// Assert the result is identical
+
+		Assert.assertEquals(
+			simpeEntryScopeAliases2.toString(), simpeEntryScopeAliases1.size(),
+			simpeEntryScopeAliases2.size());
+
+		Set<Map.Entry<AbstractMap.SimpleEntry<String, String>, Set<String>>>
+			entrySet = simpeEntryScopeAliases1.entrySet();
+
+		Stream<Map.Entry<AbstractMap.SimpleEntry<String, String>, Set<String>>>
+			stream = entrySet.stream();
+
+		Assert.assertTrue(
+			stream.allMatch(
+				entry -> Objects.equals(
+					entry.getValue(),
+					simpeEntryScopeAliases2.get(entry.getKey()))));
+
+		// Test separate calls result in each scope mapping to a different scope
+		// alias
+
+		simpeEntryScopeAliases1 = _exerciseBuilder(
+			builder -> builder.forApplication(
+				applicationName,
+				applicationScopeAssigner -> {
+					applicationScopeAssigner.assignScope(scopesArray[0]);
+					applicationScopeAssigner.assignScope(scopesArray[1]);
+				}));
+
+		simpeEntryScopeAliases1.forEach(
+			(key, value) -> Assert.assertEquals(
+				Collections.singleton(key.getValue()), value));
+	}
+
+	private static String _getApplicationScopeAlias(
+		String applicationName, String scope) {
+
+		return applicationName + StringPool.PERIOD + scope;
+	}
+
+	private Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+		_exerciseBuilder(Consumer<OAuth2Scope.Builder> builderConsumer) {
+
+		Map<AbstractMap.SimpleEntry<String, String>, List<String>>
+			simpleEntryScopeAliases = new HashMap<>();
+
+		OAuth2Scope.Builder builder =
+			new OAuth2ApplicationScopeAliasesLocalServiceImpl.
+				OAuth2ScopeBuilderImpl(simpleEntryScopeAliases);
+
+		builderConsumer.accept(builder);
+
+		Map<AbstractMap.SimpleEntry<String, String>, Set<String>>
+			simpleEntryScopeAliasesSet = new HashMap<>();
+
+		simpleEntryScopeAliases.forEach(
+			(key, value) -> simpleEntryScopeAliasesSet.put(
+				key, new HashSet<>(value)));
+
+		return simpleEntryScopeAliasesSet;
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
@@ -24,8 +24,7 @@ import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandlerFactory
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
-import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
-import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
+import com.liferay.oauth2.provider.service.OAuth2Scope;
 import com.liferay.oauth2.provider.shortcut.internal.constants.OAuth2ProviderShortcutConstants;
 import com.liferay.oauth2.provider.shortcut.internal.spi.scope.finder.OAuth2ProviderShortcutScopeFinder;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -106,10 +105,10 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_scopeAliasesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
+		_scopesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
 
 		for (String[] sapEntryObjectArray : _SAP_ENTRY_OBJECT_ARRAYS) {
-			_scopeAliasesList.add(
+			_scopesList.add(
 				StringUtil.replaceFirst(
 					sapEntryObjectArray[0], "OAUTH2_", StringPool.BLANK));
 		}
@@ -177,19 +176,15 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 				"https://analytics.liferay.com", 0, _APPLICATION_NAME, null,
 				Collections.singletonList(
 					"https://analytics.liferay.com/oauth/receive"),
-				_scopeAliasesList, new ServiceContext());
+				this::_buildScopes, new ServiceContext());
 
 		Class<?> clazz = getClass();
 
 		InputStream inputStream = clazz.getResourceAsStream(
 			"dependencies/logo.png");
 
-		_oAuth2ApplicationLocalService.updateIcon(
+		return _oAuth2ApplicationLocalService.updateIcon(
 			oAuth2Application.getOAuth2ApplicationId(), inputStream);
-
-		_createOAuth2ScopeGrants(oAuth2Application);
-
-		return oAuth2Application;
 	}
 
 	private void _addResourcePermissions(OAuth2Application oAuth2Application)
@@ -255,21 +250,27 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 		}
 	}
 
-	private void _createOAuth2ScopeGrants(OAuth2Application oAuth2Application)
-		throws PortalException {
+	private void _buildAnalyticsCloudScopes(OAuth2Scope.Builder builder) {
+		builder.forApplication(
+			OAuth2ProviderShortcutConstants.APPLICATION_NAME,
+			applicationScopeAssigner -> _scopesList.forEach(
+				applicationScopeAssigner::assignScope));
+	}
 
-		for (String scope : _SEGMENTS_ASAH_DEFAULT_OAUTH2_SCOPE_GRANTS) {
-			_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
-				oAuth2Application.getCompanyId(),
-				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
-				"Liferay.Segments.Asah.REST",
-				"com.liferay.segments.asah.rest.impl", scope,
-				Collections.singletonList(
-					"Liferay.Segments.Asah.REST.everything"));
-		}
+	private void _buildScopes(OAuth2Scope.Builder builder) {
+		_buildAnalyticsCloudScopes(builder);
 
-		_oAuth2ApplicationLocalService.updateOAuth2Application(
-			oAuth2Application);
+		_buildSegmentsAsahScopes(builder);
+	}
+
+	private void _buildSegmentsAsahScopes(OAuth2Scope.Builder builder) {
+		builder.forApplication(
+			"Liferay.Segments.Asah.REST",
+			applicationScopeAssigner -> applicationScopeAssigner.assignScope(
+				_SEGMENTS_ASAH_DEFAULT_OAUTH2_SCOPE_GRANTS
+			).mapToScopeAlias(
+				"Liferay.Segments.Asah.REST.everything"
+			));
 	}
 
 	private static final String _APPLICATION_NAME = "Analytics Cloud";
@@ -330,13 +331,6 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
-	private OAuth2ApplicationScopeAliasesLocalService
-		_oAuth2ApplicationScopeAliasesLocalService;
-
-	@Reference
-	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
-
-	@Reference
 	private Portal _portal;
 
 	@Reference
@@ -348,7 +342,7 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 	@Reference
 	private SAPEntryLocalService _sapEntryLocalService;
 
-	private List<String> _scopeAliasesList;
+	private List<String> _scopesList;
 	private ServiceRegistration<?> _serviceRegistration;
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
@@ -253,6 +253,7 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 	private void _buildAnalyticsCloudScopes(OAuth2Scope.Builder builder) {
 		builder.forApplication(
 			OAuth2ProviderShortcutConstants.APPLICATION_NAME,
+			"com.liferay.oauth2.provider.shortcut",
 			applicationScopeAssigner -> _scopesList.forEach(
 				applicationScopeAssigner::assignScope));
 	}
@@ -265,7 +266,7 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 
 	private void _buildSegmentsAsahScopes(OAuth2Scope.Builder builder) {
 		builder.forApplication(
-			"Liferay.Segments.Asah.REST",
+			"Liferay.Segments.Asah.REST", "com.liferay.segments.asah.rest.impl",
 			applicationScopeAssigner -> applicationScopeAssigner.assignScope(
 				_SEGMENTS_ASAH_DEFAULT_OAUTH2_SCOPE_GRANTS
 			).mapToScopeAlias(

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
@@ -17,7 +17,6 @@ package com.liferay.oauth2.provider.shortcut.internal.instance.lifecycle;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
-import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
@@ -63,7 +62,7 @@ public class FragmentRendererPortalInstanceLifecycleListener
 
 		User user = _userLocalService.getDefaultUser(company.getCompanyId());
 
-		oAuth2Application = _oAuth2ApplicationLocalService.addOAuth2Application(
+		_oAuth2ApplicationLocalService.addOAuth2Application(
 			company.getCompanyId(), user.getUserId(), user.getScreenName(),
 			new ArrayList<GrantType>() {
 				{
@@ -73,38 +72,22 @@ public class FragmentRendererPortalInstanceLifecycleListener
 			},
 			user.getUserId(), _clientId, ClientProfile.NATIVE_APPLICATION.id(),
 			StringPool.BLANK, null, null, null, 0, _applicationName, null,
-			Collections.emptyList(), Collections.emptyList(),
+			Collections.emptyList(),
+			builder -> builder.forApplication(
+				"liferay-json-web-services",
+				scopeAssigner -> scopeAssigner.assignScope(
+					"everything.read"
+				).mapToScopeAlias(
+					"liferay-json-web-services.everything.read"
+				)),
 			new ServiceContext());
-
-		OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
-			_oAuth2ApplicationScopeAliasesLocalService.
-				addOAuth2ApplicationScopeAliases(
-					oAuth2Application.getCompanyId(),
-					oAuth2Application.getUserId(),
-					oAuth2Application.getUserName(),
-					oAuth2Application.getOAuth2ApplicationId(),
-					Collections.emptyList());
-
-		_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
-			oAuth2Application.getCompanyId(),
-			oAuth2ApplicationScopeAliases.getOAuth2ApplicationScopeAliasesId(),
-			"liferay-json-web-services", "com.liferay.oauth2.provider.jsonws",
-			"everything.read",
-			Collections.singletonList(
-				"liferay-json-web-services.everything.read"));
-
-		oAuth2Application.setOAuth2ApplicationScopeAliasesId(
-			oAuth2ApplicationScopeAliases.getOAuth2ApplicationScopeAliasesId());
-
-		_oAuth2ApplicationLocalService.updateOAuth2Application(
-			oAuth2Application);
 	}
 
 	@Activate
 	protected void activate(Map<String, Object> properties) {
+		_clientId = GetterUtil.getString(properties.get("clientId"));
 		_applicationName = GetterUtil.getString(
 			properties.get("applicationName"));
-		_clientId = GetterUtil.getString(properties.get("clientId"));
 	}
 
 	private String _applicationName = "Fragment Renderer";

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
@@ -75,6 +75,7 @@ public class FragmentRendererPortalInstanceLifecycleListener
 			Collections.emptyList(),
 			builder -> builder.forApplication(
 				"liferay-json-web-services",
+				"com.liferay.oauth2.provider.jsonws",
 				scopeAssigner -> scopeAssigner.assignScope(
 					"everything.read"
 				).mapToScopeAlias(


### PR DESCRIPTION
Hi Carlos. As discussed this morning, we should simply provide the bundle symbolic name via the builder and drop any LiferayOAuth2Scope resolution.

/cc @topolik