### PR TITLE
LPS-106079 Remove SPI types use from API module

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ApplicationDescriptorLocatorImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ApplicationDescriptorLocatorImpl.java
@@ -37,24 +37,6 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 public class ApplicationDescriptorLocatorImpl
 	implements ApplicationDescriptorLocator {
 
-	/**
-	 * @deprecated As of Mueller (7.2.x)
-	 */
-	@Deprecated
-	@Override
-	public ApplicationDescriptor getApplicationDescriptor(
-		String applicationName) {
-
-		ApplicationDescriptor applicationDescriptor =
-			_serviceTrackerMap.getService(applicationName);
-
-		if (applicationDescriptor == null) {
-			return _defaultApplicationDescriptor;
-		}
-
-		return applicationDescriptor;
-	}
-
 	@Override
 	public Function<Locale, String> getApplicationDescriptorFunction(
 		String applicationName) {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ApplicationDescriptorLocatorImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ApplicationDescriptorLocatorImpl.java
@@ -20,6 +20,9 @@ import com.liferay.oauth2.provider.scope.spi.application.descriptor.ApplicationD
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 
+import java.util.Locale;
+import java.util.function.Function;
+
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -34,6 +37,10 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 public class ApplicationDescriptorLocatorImpl
 	implements ApplicationDescriptorLocator {
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	@Override
 	public ApplicationDescriptor getApplicationDescriptor(
 		String applicationName) {
@@ -46,6 +53,20 @@ public class ApplicationDescriptorLocatorImpl
 		}
 
 		return applicationDescriptor;
+	}
+
+	@Override
+	public Function<Locale, String> getApplicationDescriptorFunction(
+		String applicationName) {
+
+		ApplicationDescriptor applicationDescriptor =
+			_serviceTrackerMap.getService(applicationName);
+
+		if (applicationDescriptor == null) {
+			return _defaultApplicationDescriptor::describeApplication;
+		}
+
+		return applicationDescriptor::describeApplication;
 	}
 
 	@Activate

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeDescriptorLocatorImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeDescriptorLocatorImpl.java
@@ -35,29 +35,6 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ScopeDescriptorLocator.class)
 public class ScopeDescriptorLocatorImpl implements ScopeDescriptorLocator {
 
-	/**
-	 * @deprecated As of Mueller (7.2.x)
-	 */
-	@Deprecated
-	@Override
-	public ScopeDescriptor getScopeDescriptor(
-		long companyId, String applicationName) {
-
-		return _scopedServiceTrackerMap.getService(companyId, applicationName);
-	}
-
-	/**
-	 * @deprecated As of Mueller (7.2.x)
-	 */
-	@Deprecated
-	@Override
-	public ScopeDescriptor getScopeDescriptor(String applicationName) {
-		ScopeDescriptor scopeDescriptor = _scopedServiceTrackerMap.getService(
-			0, applicationName);
-
-		return scopeDescriptor::describeScope;
-	}
-
 	@Override
 	public BiFunction<String, Locale, String> getScopeDescriptorBiFunction(
 		long companyId, String applicationName) {

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeDescriptorLocatorImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeDescriptorLocatorImpl.java
@@ -20,6 +20,9 @@ import com.liferay.oauth2.provider.scope.liferay.ScopedServiceTrackerMap;
 import com.liferay.oauth2.provider.scope.liferay.ScopedServiceTrackerMapFactory;
 import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
 
+import java.util.Locale;
+import java.util.function.BiFunction;
+
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -32,6 +35,10 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ScopeDescriptorLocator.class)
 public class ScopeDescriptorLocatorImpl implements ScopeDescriptorLocator {
 
+	/**
+	 * @deprecated As of Mueller (7.2.x)
+	 */
+	@Deprecated
 	@Override
 	public ScopeDescriptor getScopeDescriptor(
 		long companyId, String applicationName) {
@@ -45,7 +52,20 @@ public class ScopeDescriptorLocatorImpl implements ScopeDescriptorLocator {
 	@Deprecated
 	@Override
 	public ScopeDescriptor getScopeDescriptor(String applicationName) {
-		return _scopedServiceTrackerMap.getService(0, applicationName);
+		ScopeDescriptor scopeDescriptor = _scopedServiceTrackerMap.getService(
+			0, applicationName);
+
+		return scopeDescriptor::describeScope;
+	}
+
+	@Override
+	public BiFunction<String, Locale, String> getScopeDescriptorBiFunction(
+		long companyId, String applicationName) {
+
+		ScopeDescriptor scopeDescriptor = _scopedServiceTrackerMap.getService(
+			companyId, applicationName);
+
+		return scopeDescriptor::describeScope;
 	}
 
 	@Activate

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/build.gradle
@@ -3,6 +3,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")
-	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-spi")
 	compileOnly project(":core:osgi-service-tracker-collections")
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ApplicationDescriptorLocator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ApplicationDescriptorLocator.java
@@ -14,8 +14,6 @@
 
 package com.liferay.oauth2.provider.scope.liferay;
 
-import com.liferay.oauth2.provider.scope.spi.application.descriptor.ApplicationDescriptor;
-
 import java.util.Locale;
 import java.util.function.Function;
 
@@ -23,14 +21,6 @@ import java.util.function.Function;
  * @author Tomas Polesovsky
  */
 public interface ApplicationDescriptorLocator {
-
-	/**
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 * #getApplicationDescriptorFunction(String)}
-	 */
-	@Deprecated
-	public ApplicationDescriptor getApplicationDescriptor(
-		String applicationName);
 
 	public Function<Locale, String> getApplicationDescriptorFunction(
 		String applicationName);

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ApplicationDescriptorLocator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ApplicationDescriptorLocator.java
@@ -16,12 +16,23 @@ package com.liferay.oauth2.provider.scope.liferay;
 
 import com.liferay.oauth2.provider.scope.spi.application.descriptor.ApplicationDescriptor;
 
+import java.util.Locale;
+import java.util.function.Function;
+
 /**
  * @author Tomas Polesovsky
  */
 public interface ApplicationDescriptorLocator {
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link
+	 * #getApplicationDescriptorFunction(String)}
+	 */
+	@Deprecated
 	public ApplicationDescriptor getApplicationDescriptor(
+		String applicationName);
+
+	public Function<Locale, String> getApplicationDescriptorFunction(
 		String applicationName);
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ScopeDescriptorLocator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ScopeDescriptorLocator.java
@@ -16,6 +16,9 @@ package com.liferay.oauth2.provider.scope.liferay;
 
 import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
 
+import java.util.Locale;
+import java.util.function.BiFunction;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -24,6 +27,11 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ScopeDescriptorLocator {
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link
+	 * #getScopeDescriptorBiFunction(long, String)}
+	 */
+	@Deprecated
 	public ScopeDescriptor getScopeDescriptor(
 		long companyId, String applicationName);
 
@@ -32,5 +40,8 @@ public interface ScopeDescriptorLocator {
 	 */
 	@Deprecated
 	public ScopeDescriptor getScopeDescriptor(String applicationName);
+
+	public BiFunction<String, Locale, String> getScopeDescriptorBiFunction(
+		long companyId, String applicationName);
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ScopeDescriptorLocator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ScopeDescriptorLocator.java
@@ -14,8 +14,6 @@
 
 package com.liferay.oauth2.provider.scope.liferay;
 
-import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
-
 import java.util.Locale;
 import java.util.function.BiFunction;
 
@@ -26,20 +24,6 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface ScopeDescriptorLocator {
-
-	/**
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 * #getScopeDescriptorBiFunction(long, String)}
-	 */
-	@Deprecated
-	public ScopeDescriptor getScopeDescriptor(
-		long companyId, String applicationName);
-
-	/**
-	 * @deprecated As of Mueller (7.2.x)
-	 */
-	@Deprecated
-	public ScopeDescriptor getScopeDescriptor(String applicationName);
 
 	public BiFunction<String, Locale, String> getScopeDescriptorBiFunction(
 		long companyId, String applicationName);

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/resources/com/liferay/oauth2/provider/scope/liferay/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/resources/com/liferay/oauth2/provider/scope/liferay/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 2.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-liferay-api")
-	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-spi")
 	compileOnly project(":apps:product-navigation:product-navigation-personal-menu-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/AssignableScopes.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/AssignableScopes.java
@@ -17,8 +17,6 @@ package com.liferay.oauth2.provider.web.internal;
 import com.liferay.oauth2.provider.scope.liferay.ApplicationDescriptorLocator;
 import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
 import com.liferay.oauth2.provider.scope.liferay.ScopeDescriptorLocator;
-import com.liferay.oauth2.provider.scope.spi.application.descriptor.ApplicationDescriptor;
-import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
 import com.liferay.petra.string.StringUtil;
 
 import java.util.Collection;
@@ -27,6 +25,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -132,15 +132,15 @@ public class AssignableScopes {
 	}
 
 	public String getApplicationDescription(String applicationName) {
-		ApplicationDescriptor applicationDescriptor =
-			_applicationDescriptorLocator.getApplicationDescriptor(
+		Function<Locale, String> applicationDescriptorFunction =
+			_applicationDescriptorLocator.getApplicationDescriptorFunction(
 				applicationName);
 
-		if (applicationDescriptor == null) {
+		if (applicationDescriptorFunction == null) {
 			return applicationName;
 		}
 
-		return applicationDescriptor.describeApplication(_locale);
+		return applicationDescriptorFunction.apply(_locale);
 	}
 
 	public Set<String> getApplicationNames() {
@@ -176,15 +176,15 @@ public class AssignableScopes {
 	public String getScopeDescription(
 		long companyId, LiferayOAuth2Scope liferayOAuth2Scope) {
 
-		ScopeDescriptor scopeDescriptor =
-			_scopeDescriptorLocator.getScopeDescriptor(
+		BiFunction<String, Locale, String> scopeDescriptorBiFunction =
+			_scopeDescriptorLocator.getScopeDescriptorBiFunction(
 				companyId, liferayOAuth2Scope.getApplicationName());
 
-		if (scopeDescriptor == null) {
+		if (scopeDescriptorBiFunction == null) {
 			return liferayOAuth2Scope.getScope();
 		}
 
-		return scopeDescriptor.describeScope(
+		return scopeDescriptorBiFunction.apply(
 			liferayOAuth2Scope.getScope(), _locale);
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/AssignScopesDisplayContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/AssignScopesDisplayContext.java
@@ -22,7 +22,6 @@ import com.liferay.oauth2.provider.scope.liferay.ApplicationDescriptorLocator;
 import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
 import com.liferay.oauth2.provider.scope.liferay.ScopeDescriptorLocator;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
-import com.liferay.oauth2.provider.scope.spi.application.descriptor.ApplicationDescriptor;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationService;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
@@ -166,15 +165,15 @@ public class AssignScopesDisplayContext
 	}
 
 	public String getApplicationDescription(String applicationName) {
-		ApplicationDescriptor applicationDescriptor =
-			_applicationDescriptorLocator.getApplicationDescriptor(
+		Function<Locale, String> applicationDescriptorFunction =
+			_applicationDescriptorLocator.getApplicationDescriptorFunction(
 				applicationName);
 
-		if (applicationDescriptor == null) {
+		if (applicationDescriptorFunction == null) {
 			return applicationName;
 		}
 
-		return applicationDescriptor.describeApplication(_locale);
+		return applicationDescriptorFunction.apply(_locale);
 	}
 
 	public Set<String> getApplicationNames() {


### PR DESCRIPTION
Hi Carlos & @martamedio. I was just catching up on the conversation about this SPI dependency. 

I am wondering if maybe adding a new module is unnecessary complexity in this case. We could also use simple functions.

This allows us to leave the *Locators in place, which I think makes sense because they really are API.

I see one issue with this approach though, which is that in order to break the dependency we cannot gracefully deprecate methods. They have to be removed. But maybe this is ok because our other approach would require customers to update their module dependencies, so it is also a breaking change.