### PR TITLE
LPS-109250

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryServiceTest.java
@@ -193,7 +193,7 @@ public class DepotEntryServiceTest {
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			ServiceContextTestUtil.getServiceContext(
-				user.getGroupId(), user.getUserId()));
+				TestPropsValues.getGroupId(), user.getUserId()));
 
 		_depotEntries.add(depotEntry);
 

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -959,6 +959,19 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				organization = parentOrganization;
 			}
 		}
+		else {
+			String className = group.getClassName();
+
+			if (!className.isEmpty() &&
+				(hasOwnerPermission(
+					group.getCompanyId(), className, group.getClassPK(),
+					group.getCreatorUserId(), ActionKeys.UPDATE) ||
+				 hasPermission(
+					 null, className, group.getClassPK(), ActionKeys.UPDATE))) {
+
+				return true;
+			}
+		}
 
 		return false;
 	}


### PR DESCRIPTION
Hi @csierra,

I'm not completely sure this is what we need, since the depot requirements are unclear.  I think there should be something like this we can do to make the group checking more generic.

I'm not sure why they cannot use the built in group role [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java#L94) instead of wrapping the permission checker.