### PR TITLE
LPS-110482 LanguageExtender integration test

### DIFF
--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageExtension.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageExtension.java
@@ -83,13 +83,16 @@ public class LanguageExtension {
 
 			Object baseName = attributes.get("resource.bundle.base.name");
 
+			Object serviceRanking = attributes.get(Constants.SERVICE_RANKING);
+
 			if (aggregate instanceof String) {
 				int aggregateId = _atomicInteger.incrementAndGet();
 
 				ServiceTrackerResourceBundleLoader
 					serviceTrackerResourceBundleLoader =
 						new ServiceTrackerResourceBundleLoader(
-							_bundleContext, (String)aggregate, aggregateId);
+							_bundleContext, (String)aggregate,
+							GetterUtil.getInteger(serviceRanking));
 
 				attributes.put("aggregateId", String.valueOf(aggregateId));
 
@@ -110,8 +113,6 @@ public class LanguageExtension {
 					bundleWiring.getClassLoader(), (String)baseName,
 					GetterUtil.getBoolean(excludePortalResources));
 			}
-
-			Object serviceRanking = attributes.get(Constants.SERVICE_RANKING);
 
 			if (Validator.isNotNull(serviceRanking)) {
 				attributes.put(

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageExtension.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageExtension.java
@@ -91,7 +91,7 @@ public class LanguageExtension {
 				ServiceTrackerResourceBundleLoader
 					serviceTrackerResourceBundleLoader =
 						new ServiceTrackerResourceBundleLoader(
-							_bundleContext, (String)aggregate,
+							_bundleContext, (String)aggregate, aggregateId,
 							GetterUtil.getInteger(serviceRanking));
 
 				attributes.put("aggregateId", String.valueOf(aggregateId));

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/ServiceTrackerResourceBundleLoader.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/ServiceTrackerResourceBundleLoader.java
@@ -36,7 +36,8 @@ public class ServiceTrackerResourceBundleLoader
 	implements ResourceBundleLoader {
 
 	public ServiceTrackerResourceBundleLoader(
-			BundleContext bundleContext, String aggregate, int serviceRanking)
+			BundleContext bundleContext, String aggregate, int aggregateId,
+			int serviceRanking)
 		throws InvalidSyntaxException {
 
 		List<String> filterStrings = StringUtil.split(aggregate);
@@ -47,7 +48,8 @@ public class ServiceTrackerResourceBundleLoader
 			Filter filter = bundleContext.createFilter(
 				StringBundler.concat(
 					"(&(objectClass=", ResourceBundleLoader.class.getName(),
-					")", filterString, "(!(service.ranking>=", serviceRanking,
+					")", filterString, "(|(!(aggregateId=*))(!(aggregateId=",
+					aggregateId, ")))(!(service.ranking>=", serviceRanking,
 					")))"));
 
 			ServiceTracker<ResourceBundleLoader, ResourceBundleLoader>
@@ -78,9 +80,7 @@ public class ServiceTrackerResourceBundleLoader
 			ResourceBundleLoader resourceBundleLoader =
 				serviceTracker.getService();
 
-			if ((resourceBundleLoader != null) &&
-				(resourceBundleLoader != this)) {
-
+			if (resourceBundleLoader != null) {
 				ResourceBundle resourceBundle =
 					resourceBundleLoader.loadResourceBundle(locale);
 

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/ServiceTrackerResourceBundleLoader.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/ServiceTrackerResourceBundleLoader.java
@@ -47,7 +47,7 @@ public class ServiceTrackerResourceBundleLoader
 			Filter filter = bundleContext.createFilter(
 				StringBundler.concat(
 					"(&(objectClass=", ResourceBundleLoader.class.getName(),
-					")", filterString, "(|(!(aggregateId=*))(!(aggregateId=",
+					")", filterString, "(|(!(aggregateId=*))(!(aggregateId>=",
 					aggregateId, "))))"));
 
 			ServiceTracker<ResourceBundleLoader, ResourceBundleLoader>

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/ServiceTrackerResourceBundleLoader.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/ServiceTrackerResourceBundleLoader.java
@@ -78,7 +78,9 @@ public class ServiceTrackerResourceBundleLoader
 			ResourceBundleLoader resourceBundleLoader =
 				serviceTracker.getService();
 
-			if (resourceBundleLoader != null) {
+			if ((resourceBundleLoader != null) &&
+				(resourceBundleLoader != this)) {
+
 				ResourceBundle resourceBundle =
 					resourceBundleLoader.loadResourceBundle(locale);
 

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/ServiceTrackerResourceBundleLoader.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/ServiceTrackerResourceBundleLoader.java
@@ -36,7 +36,7 @@ public class ServiceTrackerResourceBundleLoader
 	implements ResourceBundleLoader {
 
 	public ServiceTrackerResourceBundleLoader(
-			BundleContext bundleContext, String aggregate, int aggregateId)
+			BundleContext bundleContext, String aggregate, int serviceRanking)
 		throws InvalidSyntaxException {
 
 		List<String> filterStrings = StringUtil.split(aggregate);
@@ -47,8 +47,8 @@ public class ServiceTrackerResourceBundleLoader
 			Filter filter = bundleContext.createFilter(
 				StringBundler.concat(
 					"(&(objectClass=", ResourceBundleLoader.class.getName(),
-					")", filterString, "(|(!(aggregateId=*))(!(aggregateId>=",
-					aggregateId, "))))"));
+					")", filterString, "(!(service.ranking>=", serviceRanking,
+					")))"));
 
 			ServiceTracker<ResourceBundleLoader, ResourceBundleLoader>
 				serviceTracker = new ServiceTracker<>(

--- a/modules/apps/portal-language/portal-language-test/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-test/bnd.bnd
@@ -11,5 +11,5 @@ Provide-Capability:\
 	liferay.resource.bundle;\
 		bundle.symbolic.name=language.test.symbolic.name.2;\
 		resource.bundle.aggregate:String="(bundle.symbolic.name=language.test.symbolic.name.3),(bundle.symbolic.name=language.test.symbolic.name.2)";\
-		resource.bundle.base.name="content.Language"
+		resource.bundle.base.name="content.Language";\
 		service.ranking="2"

--- a/modules/apps/portal-language/portal-language-test/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-test/bnd.bnd
@@ -1,3 +1,15 @@
 Bundle-Name: Liferay Portal Language Test
 Bundle-SymbolicName: com.liferay.portal.language.test
 Bundle-Version: 1.0.0
+Provide-Capability:\
+	liferay.resource.bundle;\
+		bundle.symbolic.name=language.test.symbolic.name.1;\
+		resource.bundle.aggregate:String="(bundle.symbolic.name=language.test.symbolic.name.1),(bundle.symbolic.name=language.test.symbolic.name.2)";\
+		resource.bundle.base.name="content.Language";\
+		service.ranking="1";\
+		servlet.context.name=language-test,\
+	liferay.resource.bundle;\
+		bundle.symbolic.name=language.test.symbolic.name.2;\
+		resource.bundle.aggregate:String="(bundle.symbolic.name=language.test.symbolic.name.3),(bundle.symbolic.name=language.test.symbolic.name.2)";\
+		resource.bundle.base.name="content.Language"
+		service.ranking="2"

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/extender/test/LanguageExtenderTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/extender/test/LanguageExtenderTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.language.extender.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.ListIterator;
+import java.util.ListResourceBundle;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Stian Sigvartsen
+ */
+@RunWith(Arquillian.class)
+public class LanguageExtenderTest {
+
+	@Before
+	public void setUp() throws Exception {
+		_bundleActivator = new LanguageExtenderTestPreparatorBundleActivator();
+
+		_bundle = FrameworkUtil.getBundle(LanguageExtenderTest.class);
+
+		_bundleContext = _bundle.getBundleContext();
+
+		_bundleActivator.start(_bundleContext);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_bundleActivator.stop(_bundleContext);
+	}
+
+	@Test
+	public void test() {
+		String servletContextName = "language-test";
+
+		ResourceBundleLoader resourceBundleLoader =
+			ResourceBundleLoaderUtil.
+				getResourceBundleLoaderByServletContextName(servletContextName);
+
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
+			new Locale("en", "US"));
+
+		Assert.assertEquals(
+			"1", ResourceBundleUtil.getString(resourceBundle, "test.key1"));
+		Assert.assertEquals(
+			"2", ResourceBundleUtil.getString(resourceBundle, "test.key2"));
+		Assert.assertEquals(
+			"3", ResourceBundleUtil.getString(resourceBundle, "test.key3"));
+
+		Assert.assertEquals(
+			"1",
+			ResourceBundleUtil.getString(resourceBundle, "test.collision1"));
+		Assert.assertEquals(
+			"3",
+			ResourceBundleUtil.getString(resourceBundle, "test.collision2"));
+	}
+
+	public static class LanguageExtenderTestPreparatorBundleActivator
+		implements BundleActivator {
+
+		@Override
+		public void start(BundleContext bundleContext) throws Exception {
+			_bundleContext = bundleContext;
+			autoCloseables = new ArrayList<>();
+
+			try {
+				prepareTest();
+			}
+			catch (Exception exception) {
+				_cleanUp();
+
+				throw new RuntimeException(exception);
+			}
+		}
+
+		@Override
+		public void stop(BundleContext bundleContext) throws Exception {
+			_cleanUp();
+		}
+
+		protected void prepareTest() throws Exception {
+			_registerResourceBundleLoader(
+				"language.test.symbolic.name.1",
+				createResourceBundle("test.key1", "1", "test.collision1", "1"));
+
+			_registerResourceBundleLoader(
+				"language.test.symbolic.name.2",
+				createResourceBundle("test.key2", "2", "test.collision2", "2"));
+
+			_registerResourceBundleLoader(
+				"language.test.symbolic.name.3",
+				createResourceBundle(
+					"test.key3", "3", "test.collision1", "3", "test.collision2",
+					"3"));
+		}
+
+		protected ArrayList<AutoCloseable> autoCloseables;
+
+		private void _cleanUp() {
+			ListIterator<AutoCloseable> listIterator =
+				autoCloseables.listIterator(autoCloseables.size());
+
+			while (listIterator.hasPrevious()) {
+				AutoCloseable previousAutoCloseable = listIterator.previous();
+
+				try {
+					previousAutoCloseable.close();
+				}
+				catch (Exception exception) {
+					_log.error(exception, exception);
+				}
+			}
+		}
+
+		private void _registerResourceBundleLoader(
+			String bundleSymbolicName, ResourceBundle resourceBundle) {
+
+			Dictionary<String, Object> properties;
+			properties = new HashMapDictionary<>();
+
+			properties.put("service.ranking", Integer.MIN_VALUE);
+
+			properties.put("bundle.symbolic.name", bundleSymbolicName);
+			properties.put("resource.bundle.base.name", "content.Language");
+
+			ServiceRegistration<ResourceBundleLoader> serviceRegistration =
+				_bundleContext.registerService(
+					ResourceBundleLoader.class, locale -> resourceBundle,
+					properties);
+
+			autoCloseables.add(serviceRegistration::unregister);
+		}
+
+		private static final Log _log = LogFactoryUtil.getLog(
+			LanguageExtenderTestPreparatorBundleActivator.class);
+
+		private BundleContext _bundleContext;
+
+	}
+
+	protected static ResourceBundle createResourceBundle(
+		final String... keysAndValues) {
+
+		if ((keysAndValues.length % 2) != 0) {
+			throw new RuntimeException(
+				"Keys and values length is not an even number");
+		}
+
+		return new ListResourceBundle() {
+
+			@Override
+			protected Object[][] getContents() {
+				Object[][] contents = new Object[keysAndValues.length / 2][];
+
+				for (int i = 0; i < contents.length; i++) {
+					contents[i] = new Object[] {
+						keysAndValues[i * 2], keysAndValues[i * 2 + 1]
+					};
+				}
+
+				return contents;
+			}
+
+		};
+	}
+
+	private Bundle _bundle;
+	private BundleActivator _bundleActivator;
+	private BundleContext _bundleContext;
+
+}


### PR DESCRIPTION
Hi Carlos. This test implements the scenario that we discussed isn't working with the partial fix added via the earlier commits in this pull request.

After our conversation on Friday I realized that I could cut through all the complexity of multiple "-test" modules and custom build scripts if I just add the aggregate directives to the test module's ```bnd.bnd``` .

I have also isolated the ResourceBundles and aggregates used in the test away from the default resource bundle / ```bundle.symbolic.name``` of the test module.

I am wondering if the test would be more complete if a 3rd aggregate was added with a lower ```service.ranking``` than the one with ```servlet.context.name``` . That might further highlight that we cannot include the directive's ```service.ranking``` in the OSGi filters used in ```ServiceTrackerResourceBundleLoader``` to achieve the order. Thoughts?