### PR TITLE
LPS-105158 SF rename

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
@@ -105,10 +105,10 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_scopesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
+		_scopeAliasesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
 
 		for (String[] sapEntryObjectArray : _SAP_ENTRY_OBJECT_ARRAYS) {
-			_scopesList.add(
+			_scopeAliasesList.add(
 				StringUtil.replaceFirst(
 					sapEntryObjectArray[0], "OAUTH2_", StringPool.BLANK));
 		}
@@ -254,7 +254,7 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 		builder.forApplication(
 			OAuth2ProviderShortcutConstants.APPLICATION_NAME,
 			"com.liferay.oauth2.provider.shortcut",
-			applicationScopeAssigner -> _scopesList.forEach(
+			applicationScopeAssigner -> _scopeAliasesList.forEach(
 				applicationScopeAssigner::assignScope));
 	}
 
@@ -343,7 +343,7 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 	@Reference
 	private SAPEntryLocalService _sapEntryLocalService;
 
-	private List<String> _scopesList;
+	private List<String> _scopeAliasesList;
 	private ServiceRegistration<?> _serviceRegistration;
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
@@ -105,10 +105,10 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_scopeAliasesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
+		_scopesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
 
 		for (String[] sapEntryObjectArray : _SAP_ENTRY_OBJECT_ARRAYS) {
-			_scopeAliasesList.add(
+			_scopesList.add(
 				StringUtil.replaceFirst(
 					sapEntryObjectArray[0], "OAUTH2_", StringPool.BLANK));
 		}
@@ -254,7 +254,7 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 		builder.forApplication(
 			OAuth2ProviderShortcutConstants.APPLICATION_NAME,
 			"com.liferay.oauth2.provider.shortcut",
-			applicationScopeAssigner -> _scopeAliasesList.forEach(
+			applicationScopeAssigner -> _scopesList.forEach(
 				applicationScopeAssigner::assignScope));
 	}
 
@@ -343,7 +343,7 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 	@Reference
 	private SAPEntryLocalService _sapEntryLocalService;
 
-	private List<String> _scopeAliasesList;
+	private List<String> _scopesList;
 	private ServiceRegistration<?> _serviceRegistration;
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
@@ -26,4 +26,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+
+	testCompile group: "junit", name: "junit", version: "4.12"
+	testCompile project(":apps:oauth2-provider:oauth2-provider-scope-impl")
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+	compileInclude group: "org.jgrapht", name: "jgrapht-core", version: "1.3.0"
+	compileInclude group: "org.jheaps", name: "jheaps", version: "0.9"
+
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"

--- a/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/AssignScopesDisplayContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/AssignScopesDisplayContext.java
@@ -209,18 +209,18 @@ public class AssignScopesDisplayContext
 
 		Stream<String> stream = applicationScopeDescription.stream();
 
-		List<String> scopesList = stream.sorted(
+		List<String> scopeAliasesList = stream.sorted(
 		).map(
 			HtmlUtil::escape
 		).collect(
 			Collectors.toList()
 		);
 
-		if (ListUtil.isEmpty(scopesList)) {
+		if (ListUtil.isEmpty(scopeAliasesList)) {
 			return StringPool.BLANK;
 		}
 
-		return StringUtil.merge(scopesList, delimiter);
+		return StringUtil.merge(scopeAliasesList, delimiter);
 	}
 
 	public Map<AssignableScopes, Relations> getAssignableScopesRelations(

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/AssignScopesDisplayContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/AssignScopesDisplayContext.java
@@ -209,18 +209,18 @@ public class AssignScopesDisplayContext
 
 		Stream<String> stream = applicationScopeDescription.stream();
 
-		List<String> scopeAliasesList = stream.sorted(
+		List<String> scopesList = stream.sorted(
 		).map(
 			HtmlUtil::escape
 		).collect(
 			Collectors.toList()
 		);
 
-		if (ListUtil.isEmpty(scopeAliasesList)) {
+		if (ListUtil.isEmpty(scopesList)) {
 			return StringPool.BLANK;
 		}
 
-		return StringUtil.merge(scopeAliasesList, delimiter);
+		return StringUtil.merge(scopesList, delimiter);
 	}
 
 	public Map<AssignableScopes, Relations> getAssignableScopesRelations(

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/Tree.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/Tree.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.tree;
+
+import com.liferay.oauth2.provider.web.internal.tree.visitor.TreeVisitor;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Marta Medio
+ */
+public abstract class Tree<T> {
+
+	public abstract <R> R accept(TreeVisitor<T, R> treeVisitor);
+
+	public abstract T getValue();
+
+	public static final class Leaf<T> extends Tree<T> {
+
+		public Leaf(T value) {
+			_value = value;
+		}
+
+		@Override
+		public <R> R accept(TreeVisitor<T, R> treeVisitor) {
+			return treeVisitor.visitLeaf(this);
+		}
+
+		@Override
+		public T getValue() {
+			return _value;
+		}
+
+		private final T _value;
+
+	}
+
+	public static final class Node<T> extends Tree<T> {
+
+		public Node(T value, List<Tree<T>> trees) {
+			_value = value;
+			_trees = trees;
+		}
+
+		public Node(T value, Tree<T>... trees) {
+			this(value, Arrays.asList(trees));
+		}
+
+		@Override
+		public <R> R accept(TreeVisitor<T, R> treeVisitor) {
+			return treeVisitor.visitNode(this);
+		}
+
+		public List<Tree<T>> getTrees() {
+			return _trees;
+		}
+
+		@Override
+		public T getValue() {
+			return _value;
+		}
+
+		private final List<Tree<T>> _trees;
+		private final T _value;
+
+	}
+
+	private Tree() {
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/RenderChildrenTag.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/RenderChildrenTag.java
@@ -45,12 +45,12 @@ public class RenderChildrenTag extends TreeTag {
 		Deque<Tree.Node<?>> parentNodes =
 			(Deque<Tree.Node<?>>)jspContext.getAttribute("parentNodes");
 
-		Tree.Node<?> treeNode = (Tree.Node<?>)treeObject;
+		Tree.Node<?> node = (Tree.Node<?>)treeObject;
 
-		parentNodes.push(treeNode);
+		parentNodes.push(node);
 
 		try {
-			for (Tree<?> tree : treeNode.getTrees()) {
+			for (Tree<?> tree : node.getTrees()) {
 				renderTree(tree);
 			}
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/RenderChildrenTag.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/RenderChildrenTag.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.tree.tag;
+
+import com.liferay.oauth2.provider.web.internal.tree.Tree;
+
+import java.io.IOException;
+
+import java.util.Deque;
+
+import javax.servlet.jsp.JspContext;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.JspFragment;
+import javax.servlet.jsp.tagext.JspTag;
+
+/**
+ * @author Marta Medio
+ */
+public class RenderChildrenTag extends TreeTag {
+
+	@Override
+	public void doTag() throws IOException, JspException {
+		JspContext jspContext = getJspContext();
+
+		Object treeObject = jspContext.getAttribute("tree");
+
+		if (!(treeObject instanceof Tree.Node)) {
+			throw new IllegalStateException(
+				"Render children has to be used inside the node fragment of " +
+					"a tree tag");
+		}
+
+		Deque<Tree.Node<?>> parentNodes =
+			(Deque<Tree.Node<?>>)jspContext.getAttribute("parentNodes");
+
+		Tree.Node<?> treeNode = (Tree.Node<?>)treeObject;
+
+		parentNodes.push(treeNode);
+
+		try {
+			for (Tree<?> tree : treeNode.getTrees()) {
+				renderTree(tree);
+			}
+		}
+		finally {
+			parentNodes.pop();
+		}
+	}
+
+	@Override
+	public JspFragment getLeafJspFragment() {
+		if (leafJspFragment != null) {
+			return leafJspFragment;
+		}
+
+		JspTag jspTag = findAncestorWithClass(this, TreeTag.class);
+
+		if (jspTag instanceof TreeTag) {
+			TreeTag treeTag = (TreeTag)jspTag;
+
+			return treeTag.getLeafJspFragment();
+		}
+
+		throw new IllegalStateException("Can not find leaf fragment");
+	}
+
+	@Override
+	public JspFragment getNodeJspFragment() {
+		if (nodeJspFragment != null) {
+			return nodeJspFragment;
+		}
+
+		JspTag jspTag = findAncestorWithClass(this, TreeTag.class);
+
+		if (jspTag instanceof TreeTag) {
+			TreeTag treeTag = (TreeTag)jspTag;
+
+			return treeTag.getNodeJspFragment();
+		}
+
+		throw new IllegalStateException("Can not find node fragment");
+	}
+
+	public void setLeafJspFragment(JspFragment leafJspFragment) {
+		this.leafJspFragment = leafJspFragment;
+	}
+
+	public void setNodeJspFragment(JspFragment nodeJspFragment) {
+		this.nodeJspFragment = nodeJspFragment;
+	}
+
+	protected JspFragment leafJspFragment;
+	protected JspFragment nodeJspFragment;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/RenderChildrenTag.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/RenderChildrenTag.java
@@ -73,7 +73,7 @@ public class RenderChildrenTag extends TreeTag {
 			return treeTag.getLeafJspFragment();
 		}
 
-		throw new IllegalStateException("Can not find leaf fragment");
+		throw new IllegalStateException("Unable to get leaf JSP fragment");
 	}
 
 	@Override
@@ -90,7 +90,7 @@ public class RenderChildrenTag extends TreeTag {
 			return treeTag.getNodeJspFragment();
 		}
 
-		throw new IllegalStateException("Can not find node fragment");
+		throw new IllegalStateException("Unable to get node JSP fragment");
 	}
 
 	public void setLeafJspFragment(JspFragment leafJspFragment) {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/TreeTag.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/TreeTag.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.tree.tag;
+
+import com.liferay.oauth2.provider.web.internal.tree.Tree;
+
+import java.io.IOException;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+import javax.servlet.jsp.JspContext;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.JspFragment;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+/**
+ * @author Marta Medio
+ */
+public class TreeTag extends SimpleTagSupport {
+
+	@Override
+	public void doTag() throws IOException, JspException {
+		JspContext jspContext = getJspContext();
+
+		Object parentNodes = jspContext.getAttribute("parentNodes");
+
+		try {
+			jspContext.setAttribute("parentNodes", new LinkedList<>());
+
+			for (Tree<?> tree : _trees) {
+				renderTree(tree);
+			}
+		}
+		finally {
+			if (parentNodes == null) {
+				jspContext.removeAttribute("parentNodes");
+			}
+			else {
+				jspContext.setAttribute("parentNodes", parentNodes);
+			}
+		}
+	}
+
+	public JspFragment getLeafJspFragment() {
+		return leafJspFragment;
+	}
+
+	public JspFragment getNodeJspFragment() {
+		return nodeJspFragment;
+	}
+
+	public Collection<Tree<?>> getTrees() {
+		return _trees;
+	}
+
+	public void setLeafJspFragment(JspFragment leafJspFragment) {
+		this.leafJspFragment = leafJspFragment;
+	}
+
+	public void setNodeJspFragment(JspFragment nodeJspFragment) {
+		this.nodeJspFragment = nodeJspFragment;
+	}
+
+	public void setTrees(Collection trees) {
+		_trees = (Collection)trees;
+	}
+
+	protected void renderTree(Tree<?> tree) throws IOException, JspException {
+		JspContext jspContext = getJspContext();
+
+		Object treeObject = jspContext.getAttribute("tree");
+
+		try {
+			jspContext.setAttribute("tree", tree);
+
+			if (tree instanceof Tree.Leaf) {
+				getLeafJspFragment().invoke(null);
+			}
+			else {
+				getNodeJspFragment().invoke(null);
+			}
+		}
+		finally {
+			if (treeObject == null) {
+				jspContext.removeAttribute("tree");
+			}
+			else {
+				jspContext.setAttribute("tree", treeObject);
+			}
+		}
+	}
+
+	protected JspFragment leafJspFragment;
+	protected JspFragment nodeJspFragment;
+
+	private Collection<Tree<?>> _trees;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/util/TreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/util/TreeUtil.java
@@ -131,15 +131,11 @@ public class TreeUtil {
 			Set<T> visitedVerticesSet = visitedVerticesMap.computeIfAbsent(
 				pathKey, key -> new HashSet<>());
 
-			List<T> vertexList = graphPath.getVertexList();
-
 			Set<String> visitedEdgesSet = visitedEdgesMap.computeIfAbsent(
 				pathKey, key -> new HashSet<>());
 
-			List<String> edgeList = graphPath.getEdgeList();
-
-			if (visitedVerticesSet.containsAll(vertexList)) {
-				for (String edge : edgeList) {
+			if (visitedVerticesSet.containsAll(graphPath.getVertexList())) {
+				for (String edge : graphPath.getEdgeList()) {
 					if (!visitedEdgesSet.contains(edge)) {
 						directedAcyclicGraph.removeEdge(edge);
 					}
@@ -148,8 +144,8 @@ public class TreeUtil {
 				continue;
 			}
 
-			visitedEdgesSet.addAll(edgeList);
-			visitedVerticesSet.addAll(vertexList);
+			visitedEdgesSet.addAll(graphPath.getEdgeList());
+			visitedVerticesSet.addAll(graphPath.getVertexList());
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/util/TreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/util/TreeUtil.java
@@ -113,30 +113,30 @@ public class TreeUtil {
 		AllDirectedPaths<T, String> allDirectedPaths = new AllDirectedPaths<>(
 			directedAcyclicGraph);
 
-		List<GraphPath<T, String>> allPaths = allDirectedPaths.getAllPaths(
+		List<GraphPath<T, String>> allGraphPaths = allDirectedPaths.getAllPaths(
 			initialVertices, endingVertices, true, null);
 
 		Comparator<GraphPath<?, ?>> comparator = Comparator.comparingInt(
 			GraphPath::getLength);
 
-		allPaths.sort(comparator.reversed());
+		allGraphPaths.sort(comparator.reversed());
 
 		HashMap<String, Set<String>> visitedEdgesMap = new HashMap<>();
 		HashMap<String, Set<T>> visitedVerticesMap = new HashMap<>();
 
-		for (GraphPath<T, String> path : allPaths) {
+		for (GraphPath<T, String> graphPath : allGraphPaths) {
 			String pathKey = StringBundler.concat(
-				path.getStartVertex(), "#", path.getEndVertex());
+				graphPath.getStartVertex(), "#", graphPath.getEndVertex());
 
 			Set<T> visitedVerticesSet = visitedVerticesMap.computeIfAbsent(
 				pathKey, key -> new HashSet<>());
 
-			List<T> vertexList = path.getVertexList();
+			List<T> vertexList = graphPath.getVertexList();
 
 			Set<String> visitedEdgesSet = visitedEdgesMap.computeIfAbsent(
 				pathKey, key -> new HashSet<>());
 
-			List<String> edgeList = path.getEdgeList();
+			List<String> edgeList = graphPath.getEdgeList();
 
 			if (visitedVerticesSet.containsAll(vertexList)) {
 				for (String edge : edgeList) {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/util/TreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/util/TreeUtil.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.tree.util;
+
+import com.liferay.oauth2.provider.web.internal.tree.Tree;
+import com.liferay.petra.string.StringBundler;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.AllDirectedPaths;
+import org.jgrapht.graph.DirectedAcyclicGraph;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class TreeUtil {
+
+	public static <T> Tree.Node<T> getTreeNode(
+		Set<T> set, T rootValue, BiPredicate<T, T> biPredicate) {
+
+		DirectedAcyclicGraph<T, String> directedAcyclicGraph =
+			new DirectedAcyclicGraph<>(String.class);
+
+		for (T vertex1 : set) {
+			directedAcyclicGraph.addVertex(vertex1);
+
+			for (T vertex2 : set) {
+				if (Objects.equals(vertex1, vertex2)) {
+					continue;
+				}
+
+				if (biPredicate.test(vertex1, vertex2)) {
+					directedAcyclicGraph.addVertex(vertex2);
+
+					directedAcyclicGraph.addEdge(
+						vertex1, vertex2,
+						StringBundler.concat(vertex1, "#", vertex2));
+				}
+			}
+		}
+
+		Set<T> endingVertices = new HashSet<>();
+		Set<T> initialVertices = new HashSet<>();
+
+		for (T vertex : set) {
+			if (directedAcyclicGraph.outDegreeOf(vertex) == 0) {
+				endingVertices.add(vertex);
+			}
+
+			if (directedAcyclicGraph.inDegreeOf(vertex) == 0) {
+				initialVertices.add(vertex);
+			}
+		}
+
+		_filterRedundantPaths(
+			directedAcyclicGraph, initialVertices, endingVertices);
+
+		return _createTreeNode(
+			directedAcyclicGraph, rootValue, initialVertices);
+	}
+
+	private static <T, E> Tree<T> _createTree(Graph<T, E> graph, T value) {
+		if (graph.outDegreeOf(value) == 0) {
+			return new Tree.Leaf<>(value);
+		}
+
+		Set<T> set = new HashSet<>();
+
+		for (E edge : graph.outgoingEdgesOf(value)) {
+			set.add(graph.getEdgeTarget(edge));
+		}
+
+		return _createTreeNode(graph, value, set);
+	}
+
+	private static <T> Tree.Node<T> _createTreeNode(
+		Graph<T, ?> graph, T value, Set<T> set) {
+
+		List<Tree<T>> trees = new ArrayList<>();
+
+		for (T childValue : set) {
+			trees.add(_createTree(graph, childValue));
+		}
+
+		return new Tree.Node<>(value, trees);
+	}
+
+	private static <T> void _filterRedundantPaths(
+		DirectedAcyclicGraph<T, String> directedAcyclicGraph,
+		Set<T> initialVertices, Set<T> endingVertices) {
+
+		AllDirectedPaths<T, String> allDirectedPaths = new AllDirectedPaths<>(
+			directedAcyclicGraph);
+
+		List<GraphPath<T, String>> allPaths = allDirectedPaths.getAllPaths(
+			initialVertices, endingVertices, true, null);
+
+		Comparator<GraphPath<?, ?>> comparator = Comparator.comparingInt(
+			GraphPath::getLength);
+
+		allPaths.sort(comparator.reversed());
+
+		HashMap<String, Set<String>> visitedEdgesMap = new HashMap<>();
+		HashMap<String, Set<T>> visitedVerticesMap = new HashMap<>();
+
+		for (GraphPath<T, String> path : allPaths) {
+			String pathKey = StringBundler.concat(
+				path.getStartVertex(), "#", path.getEndVertex());
+
+			Set<T> visitedVerticesSet = visitedVerticesMap.computeIfAbsent(
+				pathKey, key -> new HashSet<>());
+
+			List<T> vertexList = path.getVertexList();
+
+			Set<String> visitedEdgesSet = visitedEdgesMap.computeIfAbsent(
+				pathKey, key -> new HashSet<>());
+
+			List<String> edgeList = path.getEdgeList();
+
+			if (visitedVerticesSet.containsAll(vertexList)) {
+				for (String edge : edgeList) {
+					if (!visitedEdgesSet.contains(edge)) {
+						directedAcyclicGraph.removeEdge(edge);
+					}
+				}
+
+				continue;
+			}
+
+			visitedEdgesSet.addAll(edgeList);
+			visitedVerticesSet.addAll(vertexList);
+		}
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/util/TreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/util/TreeUtil.java
@@ -128,10 +128,9 @@ public class TreeUtil {
 			String pathKey = StringBundler.concat(
 				graphPath.getStartVertex(), "#", graphPath.getEndVertex());
 
-			Set<T> visitedVerticesSet = visitedVerticesMap.computeIfAbsent(
-				pathKey, key -> new HashSet<>());
-
 			Set<String> visitedEdgesSet = visitedEdgesMap.computeIfAbsent(
+				pathKey, key -> new HashSet<>());
+			Set<T> visitedVerticesSet = visitedVerticesMap.computeIfAbsent(
 				pathKey, key -> new HashSet<>());
 
 			if (visitedVerticesSet.containsAll(graphPath.getVertexList())) {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/visitor/TreeVisitor.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/visitor/TreeVisitor.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.tree.visitor;
+
+import com.liferay.oauth2.provider.web.internal.tree.Tree;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public interface TreeVisitor<T, R> {
+
+	public R visitLeaf(Tree.Leaf<T> leaf);
+
+	public R visitNode(Tree.Node<T> node);
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
@@ -23,6 +23,7 @@ import com.liferay.petra.string.StringPool;
 
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,6 +34,13 @@ import java.util.stream.Stream;
  * @author Marta Medio
  */
 public class ScopeTreeUtil {
+
+	public static Tree.Node<String> getScopeTreeNode(
+		List<String> scopeAliases, ScopeMatcherFactory scopeMatcherFactory) {
+
+		return getScopeTreeNode(
+			new HashSet<>(scopeAliases), scopeMatcherFactory);
+	}
 
 	public static Tree.Node<String> getScopeTreeNode(
 		Set<String> scopeAliases, ScopeMatcherFactory scopeMatcherFactory) {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
@@ -47,7 +47,7 @@ public class ScopeTreeUtil {
 
 		HashMap<String, ScopeMatcher> scopeMatchers = new HashMap<>();
 
-		Tree.Node<String> treeNode = TreeUtil.getTreeNode(
+		Tree.Node<String> node = TreeUtil.getTreeNode(
 			scopeAliases, StringPool.BLANK,
 			(scopeAlias1, scopeAlias2) -> {
 				ScopeMatcher scopeMatcher = scopeMatchers.computeIfAbsent(
@@ -56,7 +56,7 @@ public class ScopeTreeUtil {
 				return scopeMatcher.match(scopeAlias2);
 			});
 
-		return (Tree.Node<String>)treeNode.accept(_sortTreeVisitor);
+		return (Tree.Node<String>)node.accept(_sortTreeVisitor);
 	}
 
 	private static TreeVisitor<String, Tree<String>> _sortTreeVisitor =

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
@@ -24,7 +24,7 @@ import com.liferay.petra.string.StringPool;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -35,12 +35,13 @@ import java.util.stream.Stream;
 public class ScopeTreeUtil {
 
 	public static Tree.Node<String> getScopeTreeNode(
-		Set<String> scopeAliases, ScopeMatcherFactory scopeMatcherFactory) {
+		List<String> scopeAliasesList,
+		ScopeMatcherFactory scopeMatcherFactory) {
 
 		HashMap<String, ScopeMatcher> scopeMatcherMap = new HashMap<>();
 
 		Tree.Node<String> treeNode = TreeUtil.getTreeNode(
-			scopeAliases, StringPool.BLANK,
+			new TreeSet<String>(scopeAliasesList), StringPool.BLANK,
 			(scopeAlias1, scopeAlias2) -> {
 				ScopeMatcher scopeMatcher = scopeMatcherMap.computeIfAbsent(
 					scopeAlias1, scopeMatcherFactory::create);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
@@ -24,7 +24,7 @@ import com.liferay.petra.string.StringPool;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.TreeSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -35,13 +35,12 @@ import java.util.stream.Stream;
 public class ScopeTreeUtil {
 
 	public static Tree.Node<String> getScopeTreeNode(
-		List<String> scopeAliasesList,
-		ScopeMatcherFactory scopeMatcherFactory) {
+		Set<String> scopeAliases, ScopeMatcherFactory scopeMatcherFactory) {
 
 		HashMap<String, ScopeMatcher> scopeMatchers = new HashMap<>();
 
 		Tree.Node<String> treeNode = TreeUtil.getTreeNode(
-			new TreeSet<String>(scopeAliasesList), StringPool.BLANK,
+			scopeAliases, StringPool.BLANK,
 			(scopeAlias1, scopeAlias2) -> {
 				ScopeMatcher scopeMatcher = scopeMatchers.computeIfAbsent(
 					scopeAlias1, scopeMatcherFactory::create);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
@@ -38,12 +38,12 @@ public class ScopeTreeUtil {
 		List<String> scopeAliasesList,
 		ScopeMatcherFactory scopeMatcherFactory) {
 
-		HashMap<String, ScopeMatcher> scopeMatcherMap = new HashMap<>();
+		HashMap<String, ScopeMatcher> scopeMatchers = new HashMap<>();
 
 		Tree.Node<String> treeNode = TreeUtil.getTreeNode(
 			new TreeSet<String>(scopeAliasesList), StringPool.BLANK,
 			(scopeAlias1, scopeAlias2) -> {
-				ScopeMatcher scopeMatcher = scopeMatcherMap.computeIfAbsent(
+				ScopeMatcher scopeMatcher = scopeMatchers.computeIfAbsent(
 					scopeAlias1, scopeMatcherFactory::create);
 
 				return scopeMatcher.match(scopeAlias2);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtil.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.util;
+
+import com.liferay.oauth2.provider.scope.spi.scope.matcher.ScopeMatcher;
+import com.liferay.oauth2.provider.scope.spi.scope.matcher.ScopeMatcherFactory;
+import com.liferay.oauth2.provider.web.internal.tree.Tree;
+import com.liferay.oauth2.provider.web.internal.tree.util.TreeUtil;
+import com.liferay.oauth2.provider.web.internal.tree.visitor.TreeVisitor;
+import com.liferay.petra.string.StringPool;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Carlos Sierra
+ * @author Marta Medio
+ */
+public class ScopeTreeUtil {
+
+	public static Tree.Node<String> getScopeTreeNode(
+		Set<String> scopeAliases, ScopeMatcherFactory scopeMatcherFactory) {
+
+		HashMap<String, ScopeMatcher> scopeMatcherMap = new HashMap<>();
+
+		Tree.Node<String> treeNode = TreeUtil.getTreeNode(
+			scopeAliases, StringPool.BLANK,
+			(scopeAlias1, scopeAlias2) -> {
+				ScopeMatcher scopeMatcher = scopeMatcherMap.computeIfAbsent(
+					scopeAlias1, scopeMatcherFactory::create);
+
+				return scopeMatcher.match(scopeAlias2);
+			});
+
+		return (Tree.Node<String>)treeNode.accept(_sortTreeVisitor);
+	}
+
+	private static TreeVisitor<String, Tree<String>> _sortTreeVisitor =
+		new TreeVisitor<String, Tree<String>>() {
+
+			@Override
+			public Tree.Leaf<String> visitLeaf(Tree.Leaf<String> leaf) {
+				return leaf;
+			}
+
+			@Override
+			public Tree.Node<String> visitNode(Tree.Node<String> node) {
+				List<Tree<String>> trees = node.getTrees();
+
+				Stream<Tree<String>> stream = trees.stream();
+
+				return new Tree.Node<>(
+					node.getValue(),
+					stream.sorted(
+						Comparator.comparing(
+							Tree::getValue, String.CASE_INSENSITIVE_ORDER)
+					).map(
+						tree -> tree.accept(this)
+					).collect(
+						Collectors.toList()
+					));
+			}
+
+		};
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/oauth2-tree.tld
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/oauth2-tree.tld
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+
+<taglib
+	version="2.1"
+	xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
+>
+	<description><![CDATA[Provides the OAuth2 Tree tags, prefixed with <code>oauth2-tree:</code>.]]></description>
+	<tlib-version>1.0</tlib-version>
+	<short-name>oauth2-tree</short-name>
+	<uri>http://liferay.com/tld/oauth2-tree</uri>
+	<tag>
+		<description><![CDATA[Triggers rendering of the trees contained in the tree node currently being rendered. Can only be used inside a nodeJspFragment of an oauth2-tree:render tag.]]></description>
+		<name>render-children</name>
+		<tag-class>com.liferay.oauth2.provider.web.internal.tree.tag.RenderChildrenTag</tag-class>
+		<body-content>scriptless</body-content>
+		<variable>
+			<description><![CDATA[This variable contains the list of parent tree nodes of the current tree]]></description>
+			<name-given>parentNodes</name-given>
+			<variable-class>java.util.Collection</variable-class>
+		</variable>
+		<variable>
+			<description><![CDATA[This variable contains the tree that is currently being rendered]]></description>
+			<name-given>tree</name-given>
+			<variable-class>com.liferay.oauth2.provider.web.internal.tree.Tree</variable-class>
+		</variable>
+		<attribute>
+			<description><![CDATA[An optional JSP Fragment describing how a tree leaf is rendered. If not present the value of the enclosing tag is used.]]></description>
+			<name>leafJspFragment</name>
+			<required>false</required>
+			<fragment>true</fragment>
+		</attribute>
+		<attribute>
+			<description><![CDATA[An optional JSP Fragment describing how a tree node is rendered. If not present the value of the enclosing tag is used.]]></description>
+			<name>nodeJspFragment</name>
+			<required>false</required>
+			<fragment>true</fragment>
+		</attribute>
+	</tag>
+	<tag>
+		<name>tree</name>
+		<tag-class>com.liferay.oauth2.provider.web.internal.tree.tag.TreeTag</tag-class>
+		<body-content>scriptless</body-content>
+		<variable>
+			<description><![CDATA[This variable contains the list of parent tree nodes of the current tree]]></description>
+			<name-given>parentNodes</name-given>
+			<variable-class>java.util.Collection</variable-class>
+		</variable>
+		<variable>
+			<description><![CDATA[This variable contains the tree that is currently being rendered]]></description>
+			<name-given>tree</name-given>
+			<variable-class>com.liferay.oauth2.provider.web.internal.tree.Tree</variable-class>
+		</variable>
+		<attribute>
+			<description><![CDATA[A required JSP Fragment describing how a tree leaf is rendered.]]></description>
+			<name>leafJspFragment</name>
+			<required>true</required>
+			<fragment>true</fragment>
+		</attribute>
+		<attribute>
+			<description><![CDATA[A required JSP Fragment describing how a tree node is rendered.]]></description>
+			<name>nodeJspFragment</name>
+			<required>true</required>
+			<fragment>true</fragment>
+		</attribute>
+		<attribute>
+			<description><![CDATA[A collection of trees to be rendered]]></description>
+			<name>trees</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>java.util.Collection</type>
+		</attribute>
+	</tag>
+</taglib>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.TreeSet;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,12 +35,12 @@ public class ScopeTreeUtilTest {
 
 	@Test
 	public void testMultipleLevelsScopeTree() {
-		List<String> scopesList = Arrays.asList(
+		List<String> scopeAliasesList = Arrays.asList(
 			"everything.read", "everything.write", "everything",
 			"everything.read.user", "everything.read.user.documents");
 
 		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
-			new TreeSet<>(scopesList), _scopeMatcherFactory);
+			scopeAliasesList, _scopeMatcherFactory);
 
 		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 
@@ -76,12 +75,12 @@ public class ScopeTreeUtilTest {
 
 	@Test
 	public void testMultipleParentsScopeTree() {
-		List<String> scopesList = Arrays.asList(
+		List<String> scopeAliasesList = Arrays.asList(
 			"everything.read", "everything.write", "everything",
 			"everything.read.user", "analytics.read", "analytics");
 
 		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
-			new TreeSet<>(scopesList), _scopeMatcherFactory);
+			scopeAliasesList, _scopeMatcherFactory);
 
 		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 
@@ -108,11 +107,11 @@ public class ScopeTreeUtilTest {
 
 	@Test
 	public void testOneLevelScopeTree() {
-		List<String> scopesList = Arrays.asList(
+		List<String> scopeAliasesList = Arrays.asList(
 			"everything.read", "everything.write", "everything");
 
 		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
-			new TreeSet<>(scopesList), _scopeMatcherFactory);
+			scopeAliasesList, _scopeMatcherFactory);
 
 		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -39,12 +39,12 @@ public class ScopeTreeUtilTest {
 			"everything.read", "everything.write", "everything",
 			"everything.read.user", "everything.read.user.documents");
 
-		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
+		Tree.Node<String> node = ScopeTreeUtil.getScopeTreeNode(
 			scopeAliasesList, _scopeMatcherFactory);
 
-		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
+		Assert.assertEquals(StringPool.BLANK, node.getValue());
 
-		Tree<String> tree = _getTree(treeNode, 0);
+		Tree<String> tree = _getTree(node, 0);
 
 		Assert.assertEquals("everything", tree.getValue());
 		Assert.assertFalse(tree instanceof Tree.Leaf);
@@ -79,12 +79,12 @@ public class ScopeTreeUtilTest {
 			"everything.read", "everything.write", "everything",
 			"everything.read.user", "analytics.read", "analytics");
 
-		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
+		Tree.Node<String> node = ScopeTreeUtil.getScopeTreeNode(
 			scopeAliasesList, _scopeMatcherFactory);
 
-		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
+		Assert.assertEquals(StringPool.BLANK, node.getValue());
 
-		Tree<String> tree = _getTree(treeNode, 0);
+		Tree<String> tree = _getTree(node, 0);
 
 		Assert.assertEquals("analytics", tree.getValue());
 		Assert.assertFalse(tree instanceof Tree.Leaf);
@@ -94,7 +94,7 @@ public class ScopeTreeUtilTest {
 		Assert.assertEquals("analytics.read", firstChildTree.getValue());
 		Assert.assertTrue(firstChildTree instanceof Tree.Leaf);
 
-		Tree<String> lastTree = _getLastTree(treeNode);
+		Tree<String> lastTree = _getLastTree(node);
 
 		Assert.assertEquals("everything", lastTree.getValue());
 		Assert.assertFalse(lastTree instanceof Tree.Leaf);
@@ -110,12 +110,12 @@ public class ScopeTreeUtilTest {
 		List<String> scopeAliasesList = Arrays.asList(
 			"everything.read", "everything.write", "everything");
 
-		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
+		Tree.Node<String> node = ScopeTreeUtil.getScopeTreeNode(
 			scopeAliasesList, _scopeMatcherFactory);
 
-		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
+		Assert.assertEquals(StringPool.BLANK, node.getValue());
 
-		Tree<String> tree = _getTree(treeNode, 0);
+		Tree<String> tree = _getTree(node, 0);
 
 		Assert.assertEquals("everything", tree.getValue());
 		Assert.assertFalse(tree instanceof Tree.Leaf);
@@ -131,21 +131,21 @@ public class ScopeTreeUtilTest {
 		Assert.assertTrue(lastChildTree instanceof Tree.Leaf);
 	}
 
-	private Tree<String> _getLastTree(Tree.Node<String> treeNode) {
-		Collection<Tree<String>> trees = treeNode.getTrees();
+	private Tree<String> _getLastTree(Tree.Node<String> node) {
+		Collection<Tree<String>> trees = node.getTrees();
 
-		return _getTree(treeNode, trees.size() - 1);
+		return _getTree(node, trees.size() - 1);
 	}
 
-	private List<Tree<String>> _getSortedTrees(Tree.Node<String> treeNode) {
+	private List<Tree<String>> _getSortedTrees(Tree.Node<String> node) {
 		return ListUtil.sort(
-			treeNode.getTrees(),
+			node.getTrees(),
 			Comparator.comparing(
 				Tree::getValue, String.CASE_INSENSITIVE_ORDER));
 	}
 
-	private Tree<String> _getTree(Tree.Node<String> treeNode, int index) {
-		List<Tree<String>> trees = _getSortedTrees(treeNode);
+	private Tree<String> _getTree(Tree.Node<String> node, int index) {
+		List<Tree<String>> trees = _getSortedTrees(node);
 
 		return trees.get(index);
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -131,10 +131,10 @@ public class ScopeTreeUtilTest {
 		Assert.assertTrue(lastChildTree instanceof Tree.Leaf);
 	}
 
-	private Tree<String> _getLastTree(Tree.Node<String> node) {
-		final Collection<Tree<String>> trees = node.getTrees();
+	private Tree<String> _getLastTree(Tree.Node<String> treeNode) {
+		final Collection<Tree<String>> trees = treeNode.getTrees();
 
-		return _getTree(node, trees.size() - 1);
+		return _getTree(treeNode, trees.size() - 1);
 	}
 
 	private List<Tree<String>> _getSortedTrees(Tree.Node<String> treeNode) {
@@ -144,8 +144,8 @@ public class ScopeTreeUtilTest {
 				Tree::getValue, String.CASE_INSENSITIVE_ORDER));
 	}
 
-	private Tree<String> _getTree(Tree.Node<String> node, int indexItem) {
-		final List<Tree<String>> trees = _getSortedTrees(node);
+	private Tree<String> _getTree(Tree.Node<String> treeNode, int indexItem) {
+		final List<Tree<String>> trees = _getSortedTrees(treeNode);
 
 		return trees.get(indexItem);
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -85,17 +85,17 @@ public class ScopeTreeUtilTest {
 
 		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
 
-		Tree<String> firstTree = _getTree(rootTreeNode, 0);
+		Tree<String> tree = _getTree(rootTreeNode, 0);
 
-		Assert.assertEquals("analytics", firstTree.getValue());
-		Assert.assertFalse(firstTree instanceof Tree.Leaf);
+		Assert.assertEquals("analytics", tree.getValue());
+		Assert.assertFalse(tree instanceof Tree.Leaf);
 
 		Tree<String> lastTree = _getLastTree(rootTreeNode);
 
 		Assert.assertEquals("everything", lastTree.getValue());
 		Assert.assertFalse(lastTree instanceof Tree.Leaf);
 
-		Tree<String> childFirstTree = _getTree((Tree.Node<String>)firstTree, 0);
+		Tree<String> childFirstTree = _getTree((Tree.Node<String>)tree, 0);
 
 		Assert.assertEquals("analytics.read", childFirstTree.getValue());
 		Assert.assertTrue(childFirstTree instanceof Tree.Leaf);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -40,12 +40,12 @@ public class ScopeTreeUtilTest {
 			"everything.read", "everything.write", "everything",
 			"everything.read.user", "everything.read.user.documents");
 
-		Tree.Node<String> rootTreeNode = ScopeTreeUtil.getScopeTreeNode(
+		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
 			new TreeSet<>(scopesList), _scopeMatcherFactory);
 
-		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
+		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 
-		Tree<String> tree = _getTree(rootTreeNode, 0);
+		Tree<String> tree = _getTree(treeNode, 0);
 
 		Assert.assertEquals("everything", tree.getValue());
 		Assert.assertFalse(tree instanceof Tree.Leaf);
@@ -80,17 +80,17 @@ public class ScopeTreeUtilTest {
 			"everything.read", "everything.write", "everything",
 			"everything.read.user", "analytics.read", "analytics");
 
-		Tree.Node<String> rootTreeNode = ScopeTreeUtil.getScopeTreeNode(
+		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
 			new TreeSet<>(scopesList), _scopeMatcherFactory);
 
-		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
+		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 
-		Tree<String> tree = _getTree(rootTreeNode, 0);
+		Tree<String> tree = _getTree(treeNode, 0);
 
 		Assert.assertEquals("analytics", tree.getValue());
 		Assert.assertFalse(tree instanceof Tree.Leaf);
 
-		Tree<String> lastTree = _getLastTree(rootTreeNode);
+		Tree<String> lastTree = _getLastTree(treeNode);
 
 		Assert.assertEquals("everything", lastTree.getValue());
 		Assert.assertFalse(lastTree instanceof Tree.Leaf);
@@ -111,12 +111,12 @@ public class ScopeTreeUtilTest {
 		List<String> scopesList = Arrays.asList(
 			"everything.read", "everything.write", "everything");
 
-		Tree.Node<String> rootTreeNode = ScopeTreeUtil.getScopeTreeNode(
+		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
 			new TreeSet<>(scopesList), _scopeMatcherFactory);
 
-		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
+		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 
-		Tree<String> tree = _getTree(rootTreeNode, 0);
+		Tree<String> tree = _getTree(treeNode, 0);
 
 		Assert.assertEquals("everything", tree.getValue());
 		Assert.assertFalse(tree instanceof Tree.Leaf);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -116,7 +116,7 @@ public class ScopeTreeUtilTest {
 
 		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
 
-		final Tree<String> tree = _getTree(rootTreeNode, 0);
+		Tree<String> tree = _getTree(rootTreeNode, 0);
 
 		Assert.assertEquals("everything", tree.getValue());
 		Assert.assertFalse(tree instanceof Tree.Leaf);
@@ -133,7 +133,7 @@ public class ScopeTreeUtilTest {
 	}
 
 	private Tree<String> _getLastTree(Tree.Node<String> treeNode) {
-		final Collection<Tree<String>> trees = treeNode.getTrees();
+		Collection<Tree<String>> trees = treeNode.getTrees();
 
 		return _getTree(treeNode, trees.size() - 1);
 	}
@@ -146,7 +146,7 @@ public class ScopeTreeUtilTest {
 	}
 
 	private Tree<String> _getTree(Tree.Node<String> treeNode, int indexItem) {
-		final List<Tree<String>> trees = _getSortedTrees(treeNode);
+		List<Tree<String>> trees = _getSortedTrees(treeNode);
 
 		return trees.get(indexItem);
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -94,15 +94,15 @@ public class ScopeTreeUtilTest {
 		Assert.assertEquals("analytics.read", firstChildTree.getValue());
 		Assert.assertTrue(firstChildTree instanceof Tree.Leaf);
 
-		Tree<String> lastChildTree = _getTree((Tree.Node<String>)lastTree, 0);
-
-		Assert.assertEquals("everything.read", lastChildTree.getValue());
-		Assert.assertFalse(lastChildTree instanceof Tree.Leaf);
-
 		Tree<String> lastTree = _getLastTree(treeNode);
 
 		Assert.assertEquals("everything", lastTree.getValue());
 		Assert.assertFalse(lastTree instanceof Tree.Leaf);
+
+		Tree<String> lastChildTree = _getTree((Tree.Node<String>)lastTree, 0);
+
+		Assert.assertEquals("everything.read", lastChildTree.getValue());
+		Assert.assertFalse(lastChildTree instanceof Tree.Leaf);
 	}
 
 	@Test

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -94,9 +94,7 @@ public class ScopeTreeUtilTest {
 		Tree<String> childFirstTree = _getTree((Tree.Node<String>)firstTree, 0);
 
 		Assert.assertEquals("analytics.read", childFirstTree.getValue());
-
 		Assert.assertTrue(childFirstTree instanceof Tree.Leaf);
-
 		Assert.assertEquals("everything", lastTree.getValue());
 		Assert.assertFalse(lastTree instanceof Tree.Leaf);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -95,15 +95,15 @@ public class ScopeTreeUtilTest {
 		Assert.assertEquals("everything", lastTree.getValue());
 		Assert.assertFalse(lastTree instanceof Tree.Leaf);
 
-		Tree<String> childFirstTree = _getTree((Tree.Node<String>)tree, 0);
+		Tree<String> firstChildTree = _getTree((Tree.Node<String>)tree, 0);
 
-		Assert.assertEquals("analytics.read", childFirstTree.getValue());
-		Assert.assertTrue(childFirstTree instanceof Tree.Leaf);
+		Assert.assertEquals("analytics.read", firstChildTree.getValue());
+		Assert.assertTrue(firstChildTree instanceof Tree.Leaf);
 
-		Tree<String> childLastTree = _getTree((Tree.Node<String>)lastTree, 0);
+		Tree<String> lastChildTree = _getTree((Tree.Node<String>)lastTree, 0);
 
-		Assert.assertEquals("everything.read", childLastTree.getValue());
-		Assert.assertFalse(childLastTree instanceof Tree.Leaf);
+		Assert.assertEquals("everything.read", lastChildTree.getValue());
+		Assert.assertFalse(lastChildTree instanceof Tree.Leaf);
 	}
 
 	@Test

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -27,18 +27,12 @@ import java.util.List;
 import java.util.TreeSet;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  * @author Marta Medio
  */
 public class ScopeTreeUtilTest {
-
-	@Before
-	public void setUp() {
-		_scopeMatcherFactory = new ChunkScopeMatcherFactory();
-	}
 
 	@Test
 	public void testMultipleLevelsScopeTree() {
@@ -156,6 +150,7 @@ public class ScopeTreeUtilTest {
 		return trees.get(indexItem);
 	}
 
-	private ScopeMatcherFactory _scopeMatcherFactory;
+	private final ScopeMatcherFactory _scopeMatcherFactory =
+		new ChunkScopeMatcherFactory();
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.util;
+
+import com.liferay.oauth2.provider.scope.internal.spi.scope.matcher.ChunkScopeMatcherFactory;
+import com.liferay.oauth2.provider.scope.spi.scope.matcher.ScopeMatcherFactory;
+import com.liferay.oauth2.provider.web.internal.tree.Tree;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Marta Medio
+ */
+public class ScopeTreeUtilTest {
+
+	@Before
+	public void setUp() {
+		_scopeMatcherFactory = new ChunkScopeMatcherFactory();
+	}
+
+	@Test
+	public void testMultipleLevelsScopeTree() {
+		List<String> scopesList = Arrays.asList(
+			"everything.read", "everything.write", "everything",
+			"everything.read.user", "everything.read.user.documents");
+
+		Tree.Node<String> rootTreeNode = ScopeTreeUtil.getScopeTreeNode(
+			new TreeSet<>(scopesList), _scopeMatcherFactory);
+
+		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
+
+		Tree<String> tree = _getTree(rootTreeNode, 0);
+
+		Assert.assertEquals("everything", tree.getValue());
+		Assert.assertFalse(tree instanceof Tree.Leaf);
+
+		Tree<String> firstChildTree = _getTree((Tree.Node<String>)tree, 0);
+
+		Assert.assertEquals("everything.read", firstChildTree.getValue());
+		Assert.assertFalse(firstChildTree instanceof Tree.Leaf);
+
+		Tree<String> firstGrandChildTree = _getTree(
+			(Tree.Node<String>)firstChildTree, 0);
+
+		Assert.assertEquals(
+			"everything.read.user", firstGrandChildTree.getValue());
+		Assert.assertFalse(firstGrandChildTree instanceof Tree.Leaf);
+		Tree<String> greatGrandChildTree = _getTree(
+			(Tree.Node<String>)firstGrandChildTree, 0);
+
+		Assert.assertEquals(
+			"everything.read.user.documents", greatGrandChildTree.getValue());
+
+		Tree<String> lastChildTree = _getLastTree((Tree.Node<String>)tree);
+
+		Assert.assertEquals("everything.write", lastChildTree.getValue());
+		Assert.assertTrue(lastChildTree instanceof Tree.Leaf);
+	}
+
+	@Test
+	public void testMultipleParentsScopeTree() {
+		List<String> scopesList = Arrays.asList(
+			"everything.read", "everything.write", "everything",
+			"everything.read.user", "analytics.read", "analytics");
+
+		Tree.Node<String> rootTreeNode = ScopeTreeUtil.getScopeTreeNode(
+			new TreeSet<>(scopesList), _scopeMatcherFactory);
+
+		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
+
+		Tree<String> firstTree = _getTree(rootTreeNode, 0);
+		Tree<String> lastTree = _getLastTree(rootTreeNode);
+
+		Assert.assertEquals("analytics", firstTree.getValue());
+		Assert.assertFalse(firstTree instanceof Tree.Leaf);
+
+		Tree<String> childFirstTree = _getTree((Tree.Node<String>)firstTree, 0);
+
+		Assert.assertEquals("analytics.read", childFirstTree.getValue());
+
+		Assert.assertTrue(childFirstTree instanceof Tree.Leaf);
+
+		Assert.assertEquals("everything", lastTree.getValue());
+		Assert.assertFalse(lastTree instanceof Tree.Leaf);
+
+		Tree<String> childLastTree = _getTree((Tree.Node<String>)lastTree, 0);
+
+		Assert.assertEquals("everything.read", childLastTree.getValue());
+		Assert.assertFalse(childLastTree instanceof Tree.Leaf);
+	}
+
+	@Test
+	public void testOneLevelScopeTree() {
+		List<String> scopesList = Arrays.asList(
+			"everything.read", "everything.write", "everything");
+
+		Tree.Node<String> rootTreeNode = ScopeTreeUtil.getScopeTreeNode(
+			new TreeSet<>(scopesList), _scopeMatcherFactory);
+
+		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
+
+		final Tree<String> tree = _getTree(rootTreeNode, 0);
+
+		Assert.assertEquals("everything", tree.getValue());
+		Assert.assertFalse(tree instanceof Tree.Leaf);
+
+		Tree<String> firstChildTree = _getTree((Tree.Node<String>)tree, 0);
+
+		Assert.assertEquals("everything.read", firstChildTree.getValue());
+		Assert.assertTrue(firstChildTree instanceof Tree.Leaf);
+
+		Tree<String> lastChildTree = _getLastTree((Tree.Node<String>)tree);
+
+		Assert.assertEquals("everything.write", lastChildTree.getValue());
+		Assert.assertTrue(lastChildTree instanceof Tree.Leaf);
+	}
+
+	private Tree<String> _getLastTree(Tree.Node<String> node) {
+		final Collection<Tree<String>> trees = node.getTrees();
+
+		return _getTree(node, trees.size() - 1);
+	}
+
+	private List<Tree<String>> _getSortedTrees(Tree.Node<String> treeNode) {
+		return ListUtil.sort(
+			treeNode.getTrees(),
+			Comparator.comparing(
+				Tree::getValue, String.CASE_INSENSITIVE_ORDER));
+	}
+
+	private Tree<String> _getTree(Tree.Node<String> node, int indexItem) {
+		final List<Tree<String>> trees = _getSortedTrees(node);
+
+		return trees.get(indexItem);
+	}
+
+	private ScopeMatcherFactory _scopeMatcherFactory;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -89,11 +89,6 @@ public class ScopeTreeUtilTest {
 		Assert.assertEquals("analytics", tree.getValue());
 		Assert.assertFalse(tree instanceof Tree.Leaf);
 
-		Tree<String> lastTree = _getLastTree(treeNode);
-
-		Assert.assertEquals("everything", lastTree.getValue());
-		Assert.assertFalse(lastTree instanceof Tree.Leaf);
-
 		Tree<String> firstChildTree = _getTree((Tree.Node<String>)tree, 0);
 
 		Assert.assertEquals("analytics.read", firstChildTree.getValue());
@@ -103,6 +98,11 @@ public class ScopeTreeUtilTest {
 
 		Assert.assertEquals("everything.read", lastChildTree.getValue());
 		Assert.assertFalse(lastChildTree instanceof Tree.Leaf);
+
+		Tree<String> lastTree = _getLastTree(treeNode);
+
+		Assert.assertEquals("everything", lastTree.getValue());
+		Assert.assertFalse(lastTree instanceof Tree.Leaf);
 	}
 
 	@Test

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -144,10 +144,10 @@ public class ScopeTreeUtilTest {
 				Tree::getValue, String.CASE_INSENSITIVE_ORDER));
 	}
 
-	private Tree<String> _getTree(Tree.Node<String> treeNode, int indexItem) {
+	private Tree<String> _getTree(Tree.Node<String> treeNode, int index) {
 		List<Tree<String>> trees = _getSortedTrees(treeNode);
 
-		return trees.get(indexItem);
+		return trees.get(index);
 	}
 
 	private final ScopeMatcherFactory _scopeMatcherFactory =

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -86,17 +86,19 @@ public class ScopeTreeUtilTest {
 		Assert.assertEquals(StringPool.BLANK, rootTreeNode.getValue());
 
 		Tree<String> firstTree = _getTree(rootTreeNode, 0);
-		Tree<String> lastTree = _getLastTree(rootTreeNode);
 
 		Assert.assertEquals("analytics", firstTree.getValue());
 		Assert.assertFalse(firstTree instanceof Tree.Leaf);
+
+		Tree<String> lastTree = _getLastTree(rootTreeNode);
+
+		Assert.assertEquals("everything", lastTree.getValue());
+		Assert.assertFalse(lastTree instanceof Tree.Leaf);
 
 		Tree<String> childFirstTree = _getTree((Tree.Node<String>)firstTree, 0);
 
 		Assert.assertEquals("analytics.read", childFirstTree.getValue());
 		Assert.assertTrue(childFirstTree instanceof Tree.Leaf);
-		Assert.assertEquals("everything", lastTree.getValue());
-		Assert.assertFalse(lastTree instanceof Tree.Leaf);
 
 		Tree<String> childLastTree = _getTree((Tree.Node<String>)lastTree, 0);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,12 +36,12 @@ public class ScopeTreeUtilTest {
 
 	@Test
 	public void testMultipleLevelsScopeTree() {
-		List<String> scopeAliasesList = Arrays.asList(
+		List<String> scopesList = Arrays.asList(
 			"everything.read", "everything.write", "everything",
 			"everything.read.user", "everything.read.user.documents");
 
 		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
-			scopeAliasesList, _scopeMatcherFactory);
+			new TreeSet<>(scopesList), _scopeMatcherFactory);
 
 		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 
@@ -75,12 +76,12 @@ public class ScopeTreeUtilTest {
 
 	@Test
 	public void testMultipleParentsScopeTree() {
-		List<String> scopeAliasesList = Arrays.asList(
+		List<String> scopesList = Arrays.asList(
 			"everything.read", "everything.write", "everything",
 			"everything.read.user", "analytics.read", "analytics");
 
 		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
-			scopeAliasesList, _scopeMatcherFactory);
+			new TreeSet<>(scopesList), _scopeMatcherFactory);
 
 		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 
@@ -107,11 +108,11 @@ public class ScopeTreeUtilTest {
 
 	@Test
 	public void testOneLevelScopeTree() {
-		List<String> scopeAliasesList = Arrays.asList(
+		List<String> scopesList = Arrays.asList(
 			"everything.read", "everything.write", "everything");
 
 		Tree.Node<String> treeNode = ScopeTreeUtil.getScopeTreeNode(
-			scopeAliasesList, _scopeMatcherFactory);
+			new TreeSet<>(scopesList), _scopeMatcherFactory);
 
 		Assert.assertEquals(StringPool.BLANK, treeNode.getValue());
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/test/java/com/liferay/oauth2/provider/web/internal/util/ScopeTreeUtilTest.java
@@ -61,6 +61,7 @@ public class ScopeTreeUtilTest {
 		Assert.assertEquals(
 			"everything.read.user", firstGrandChildTree.getValue());
 		Assert.assertFalse(firstGrandChildTree instanceof Tree.Leaf);
+
 		Tree<String> greatGrandChildTree = _getTree(
 			(Tree.Node<String>)firstGrandChildTree, 0);
 


### PR DESCRIPTION
/cc @martamedio

hi Brian, 
this is the followup pull to https://github.com/brianchandotcom/liferay-portal/pull/87579

I reverted a couple of things and readded them in a slight different fashion. I hope they still achieve the same goal. There is one name change I reverted, I tried to explain in aa1cdf9 

I unified the naming of `Tree.Node` to `node` and of `Tree.Leaf` to `leaf`.

Thx!