### PR TITLE
LPS-112383 Add tests

### DIFF
--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/constants/DepotRolesConstants.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/constants/DepotRolesConstants.java
@@ -22,6 +22,9 @@ public class DepotRolesConstants {
 	public static final String ASSET_LIBRARY_ADMINISTRATOR =
 		"Asset Library Administrator";
 
+	public static final String ASSET_LIBRARY_CONNECTED_SITE_MEMBER =
+		"Asset Library Connected Site Member";
+
 	public static final String ASSET_LIBRARY_CONTENT_REVIEWER =
 		"Asset Library Content Reviewer";
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
@@ -152,6 +152,7 @@ public class DepotRolesPortalInstanceLifecycleListener
 
 	private static final String[] _DEPOT_ROLE_NAMES = {
 		DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR,
+		DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER,
 		DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER,
 		DepotRolesConstants.ASSET_LIBRARY_MEMBER,
 		DepotRolesConstants.ASSET_LIBRARY_OWNER

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/roles/admin/role/type/contributor/DepotRoleTypeContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/roles/admin/role/type/contributor/DepotRoleTypeContributor.java
@@ -98,6 +98,9 @@ public class DepotRoleTypeContributor implements RoleTypeContributor {
 			Objects.equals(
 				role.getName(), DepotRolesConstants.ASSET_LIBRARY_MEMBER) ||
 			Objects.equals(
+				role.getName(),
+				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER) ||
+			Objects.equals(
 				role.getName(), DepotRolesConstants.ASSET_LIBRARY_OWNER)) {
 
 			return false;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotMemberRoleContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotMemberRoleContributor.java
@@ -15,6 +15,9 @@
 package com.liferay.depot.internal.security.permission.contributor;
 
 import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -27,6 +30,7 @@ import com.liferay.portal.kernel.security.permission.contributor.RoleContributor
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -40,25 +44,47 @@ public class DepotMemberRoleContributor implements RoleContributor {
 
 	@Override
 	public void contribute(RoleCollection roleCollection) {
-		if (roleCollection.getGroupId() <= 0) {
-			return;
-		}
-
 		try {
+			if (roleCollection.getGroupId() <= 0) {
+				return;
+			}
+
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
+			if (!Objects.equals(GroupConstants.TYPE_DEPOT, group.getType())) {
+				return;
+			}
+
 			UserBag userBag = roleCollection.getUserBag();
 
-			if (Objects.equals(GroupConstants.TYPE_DEPOT, group.getType()) &&
-				(userBag.hasUserGroup(group) ||
-				 userBag.hasUserOrgGroup(group))) {
-
+			if (userBag.hasUserGroup(group)) {
 				Role role = _roleLocalService.getRole(
 					group.getCompanyId(),
 					DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 				roleCollection.addRoleId(role.getRoleId());
+			}
+
+			List<DepotEntryGroupRel> depotEntryGroupRels =
+				_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+					_depotEntryLocalService.getGroupDepotEntry(
+						group.getGroupId()));
+
+			for (DepotEntryGroupRel depotEntryGroupRel : depotEntryGroupRels) {
+				if (userBag.hasUserGroup(
+						_groupLocalService.getGroup(
+							depotEntryGroupRel.getToGroupId()))) {
+
+					Role role = _roleLocalService.getRole(
+						group.getCompanyId(),
+						DepotRolesConstants.
+							ASSET_LIBRARY_CONNECTED_SITE_MEMBER);
+
+					roleCollection.addRoleId(role.getRoleId());
+
+					break;
+				}
 			}
 		}
 		catch (PortalException portalException) {
@@ -68,6 +94,12 @@ public class DepotMemberRoleContributor implements RoleContributor {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DepotMemberRoleContributor.class);
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.ResourcePrimKeyException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Portlet;
@@ -540,6 +541,10 @@ public class PortletConfigurationPermissionsDisplayContext {
 		}
 
 		_roleTypes = RoleConstants.TYPES_REGULAR_AND_SITE;
+
+		if (_group.getType() == GroupConstants.TYPE_DEPOT) {
+			_roleTypes = RoleConstants.TYPES_DEPOT_AND_REGULAR;
+		}
 
 		if (ResourceActionsUtil.isPortalModelResource(getModelResource())) {
 			if (Objects.equals(

--- a/portal-kernel/src/com/liferay/portal/kernel/model/role/RoleConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/role/RoleConstants.java
@@ -102,6 +102,10 @@ public class RoleConstants {
 
 	public static final String TYPE_SITE_LABEL = "site";
 
+	public static final int[] TYPES_DEPOT_AND_REGULAR = {
+		TYPE_DEPOT, TYPE_REGULAR
+	};
+
 	public static final int[] TYPES_ORGANIZATION_AND_REGULAR = {
 		TYPE_REGULAR, TYPE_ORGANIZATION
 	};

--- a/portal-kernel/src/com/liferay/portal/kernel/model/role/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/role/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
Hey @csierra !

These changes introduce a new role to better control permissions over Depot resources.

When depot resources are accessed (viewed, updated, etc.), if the user is a member of any site connected to the depot, it will automatically have the new "Connected Site Member" role. This assignment is implicit (i.e. is done on the fly by the RoleContributor), so the behaviour is similar to the Site Member role.

This has the following benefits:
  - Site and Depot roles are now fully separated.
  - Depot admins have fine grained control over what stuff can be done by users external to the depot.

On the other hand, there's one major drawback:
  - All external users are equal, so you cannot (say) grant more permissions to Site Admins than to Site Members.

This last point is not a problem from a product perspective, though, so if you think this improves things from a security perspective, feel free to forward this.

Thanks!