### PR TITLE
LPS-114709 Avoid using jsp:attribute for the moment

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/LeafTag.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/LeafTag.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.tree.tag;
+
+import java.io.IOException;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.JspTag;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class LeafTag extends SimpleTagSupport {
+
+	@Override
+	public void doTag() throws IOException, JspException {
+		JspTag jspTag = findAncestorWithClass(this, TreeTag.class);
+
+		if (jspTag instanceof TreeTag) {
+			TreeTag treeTag = (TreeTag)jspTag;
+
+			treeTag.setLeafJspFragment(getJspBody());
+		}
+		else {
+			throw new IllegalStateException(
+				"Leaf has to be used inside a tree tag");
+		}
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/NodeTag.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/NodeTag.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.web.internal.tree.tag;
+
+import java.io.IOException;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.JspTag;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class NodeTag extends SimpleTagSupport {
+
+	@Override
+	public void doTag() throws IOException, JspException {
+		JspTag jspTag = findAncestorWithClass(this, TreeTag.class);
+
+		if (jspTag instanceof TreeTag) {
+			TreeTag treeTag = (TreeTag)jspTag;
+
+			treeTag.setNodeJspFragment(getJspBody());
+		}
+		else {
+			throw new IllegalStateException(
+				"Node has to be used inside a tree tag");
+		}
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/TreeTag.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/tree/tag/TreeTag.java
@@ -35,6 +35,8 @@ public class TreeTag extends SimpleTagSupport {
 	public void doTag() throws IOException, JspException {
 		JspContext jspContext = getJspContext();
 
+		getJspBody().invoke(null);
+
 		Object parentNodes = jspContext.getAttribute("parentNodes");
 
 		try {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tree.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tree.jsp
@@ -73,9 +73,7 @@ pageContext.setAttribute("scopeAliasesDescriptionsMap", scopeAliasesDescriptions
 							<oauth2-tree:tree
 								trees="<%= (Collection)scopeAliasTreeNode.getTrees() %>"
 							>
-								<jsp:attribute
-									name="nodeJspFragment"
-								>
+								<oauth2-tree:node>
 								<li class='borderless list-group-item<c:if test="${assignedDeletedScopeAliases.contains(tree.value)}"> removed-scope</c:if>' id="${tree.value}-container">
 									<clay:row>
 											<c:choose>
@@ -99,11 +97,9 @@ pageContext.setAttribute("scopeAliasesDescriptionsMap", scopeAliasesDescriptions
 								</li>
 
 								<oauth2-tree:render-children />
-								</jsp:attribute>
+								</oauth2-tree:node>
 
-								<jsp:attribute
-									name="leafJspFragment"
-								>
+								<oauth2-tree:leaf>
 								<li class='borderless list-group-item<c:if test="${assignedDeletedScopeAliases.contains(tree.value)}"> removed-scope</c:if>' id="${tree.value}-container">
 									<clay:row>
 											<c:choose>
@@ -125,7 +121,7 @@ pageContext.setAttribute("scopeAliasesDescriptionsMap", scopeAliasesDescriptions
 										</div>
 									</clay:row>
 								</li>
-								</jsp:attribute>
+								</oauth2-tree:leaf>
 							</oauth2-tree:tree>
 							</li>
 						</ul>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/oauth2-tree.tld
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/oauth2-tree.tld
@@ -11,6 +11,18 @@
 	<short-name>oauth2-tree</short-name>
 	<uri>http://liferay.com/tld/oauth2-tree</uri>
 	<tag>
+		<description><![CDATA[JSP Fragment describing how a tree leaf is rendered]]></description>
+		<name>leaf</name>
+		<tag-class>com.liferay.oauth2.provider.web.internal.tree.tag.LeafTag</tag-class>
+		<body-content>scriptless</body-content>
+	</tag>
+	<tag>
+		<description><![CDATA[JSP Fragment describing how a tree node is rendered]]></description>
+		<name>node</name>
+		<tag-class>com.liferay.oauth2.provider.web.internal.tree.tag.NodeTag</tag-class>
+		<body-content>scriptless</body-content>
+	</tag>
+	<tag>
 		<description><![CDATA[Triggers rendering of the trees contained in the tree node currently being rendered. Can only be used inside a nodeJspFragment of an oauth2-tree:render tag.]]></description>
 		<name>render-children</name>
 		<tag-class>com.liferay.oauth2.provider.web.internal.tree.tag.RenderChildrenTag</tag-class>
@@ -52,18 +64,6 @@
 			<name-given>tree</name-given>
 			<variable-class>com.liferay.oauth2.provider.web.internal.tree.Tree</variable-class>
 		</variable>
-		<attribute>
-			<description><![CDATA[A required JSP Fragment describing how a tree leaf is rendered.]]></description>
-			<name>leafJspFragment</name>
-			<required>true</required>
-			<fragment>true</fragment>
-		</attribute>
-		<attribute>
-			<description><![CDATA[A required JSP Fragment describing how a tree node is rendered.]]></description>
-			<name>nodeJspFragment</name>
-			<required>true</required>
-			<fragment>true</fragment>
-		</attribute>
 		<attribute>
 			<description><![CDATA[A collection of trees to be rendered]]></description>
 			<name>trees</name>


### PR DESCRIPTION
hey Brian...
this pull removes the usage of `jsp:attribute`. 
I checked the generated output for the jsp and it no longer uses `tempX` variables, so I hope this will fix the issue until we find the root cause. 

Bests. 
Carlos.