### PR TITLE
LPS-115694 Teams are the only permission entity belonging to site so we need to use the current groupId

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/hooks/useBackUrl.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/hooks/useBackUrl.es.js
@@ -12,17 +12,19 @@
  * details.
  */
 
-export const useNavigation = (history) => {
+import {useCallback, useContext} from 'react';
+import {__RouterContext as RouterContext} from 'react-router-dom';
+
+export default function useBackUrl() {
 	const {
 		location: {pathname, search},
-	} = history;
+	} = useContext(RouterContext);
 
-	const push = (url) => {
-		history.push({
+	return useCallback(
+		(url) => ({
 			pathname: url,
 			search: `?backUrl=${pathname}${search}`,
-		});
-	};
-
-	return {push};
-};
+		}),
+		[pathname, search]
+	);
+}

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/apps/ListApps.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/apps/ListApps.es.js
@@ -20,6 +20,7 @@ import {Link} from 'react-router-dom';
 import {AppContext} from '../../AppContext.es';
 import Button from '../../components/button/Button.es';
 import ListView from '../../components/list-view/ListView.es';
+import useBackUrl from '../../hooks/useBackUrl.es';
 import useDeployApp from '../../hooks/useDeployApp.es';
 import {confirmDelete} from '../../utils/client.es';
 import {fromNow} from '../../utils/time.es';
@@ -43,6 +44,7 @@ export default ({
 }) => {
 	const {getStandaloneURL} = useContext(AppContext);
 	const {deployApp, undeployApp} = useDeployApp();
+	const withBackUrl = useBackUrl();
 
 	const ACTIONS = [
 		{
@@ -88,6 +90,16 @@ export default ({
 
 	const ENDPOINT = `/o/app-builder/v1.0/data-definitions/${dataDefinitionId}/apps`;
 
+	const getEditAppUrl = ({dataDefinitionId, id}) => {
+		return withBackUrl(
+			compile(editPath[1])({
+				appId: id,
+				dataDefinitionId,
+				objectType,
+			})
+		);
+	};
+
 	return (
 		<ListView
 			actions={ACTIONS}
@@ -101,17 +113,7 @@ export default ({
 				...app,
 				dateCreated: fromNow(app.dateCreated),
 				dateModified: fromNow(app.dateModified),
-				name: (
-					<Link
-						to={compile(editPath[1])({
-							appId: app.id,
-							dataDefinitionId,
-							objectType,
-						})}
-					>
-						{app.name.en_US}
-					</Link>
-				),
+				name: <Link to={getEditAppUrl(app)}>{app.name.en_US}</Link>,
 				nameText: app.name.en_US,
 				status: (
 					<ClayLabel

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/apps/NewAppPopover.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/apps/NewAppPopover.es.js
@@ -17,7 +17,7 @@ import {compile} from 'path-to-regexp';
 import React, {useState} from 'react';
 
 import Popover from '../../components/popover/Popover.es';
-import {useNavigation} from '../../hooks/useNavigation.es';
+import useBackUrl from '../../hooks/useBackUrl.es';
 import SelectObjects from './SelectObjectsDropDown.es';
 
 const NewAppPopover = (
@@ -25,12 +25,13 @@ const NewAppPopover = (
 	forwardRef
 ) => {
 	const [selectedObject, setSelectedObject] = useState({});
-
-	const navigation = useNavigation(history);
-
+	const withBackUrl = useBackUrl();
+	
 	const onClick = () => {
-		navigation.push(
-			compile(editPath[0])({dataDefinitionId: selectedObject.id})
+		history.push(
+			withBackUrl(
+				compile(editPath[0])({dataDefinitionId: selectedObject.id})
+			)
 		);
 	};
 

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/apps/NewAppPopover.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/apps/NewAppPopover.es.js
@@ -26,7 +26,7 @@ const NewAppPopover = (
 ) => {
 	const [selectedObject, setSelectedObject] = useState({});
 	const withBackUrl = useBackUrl();
-	
+
 	const onClick = () => {
 		history.push(
 			withBackUrl(

--- a/modules/apps/app-builder/app-builder-web/test/js/constants.es.js
+++ b/modules/apps/app-builder/app-builder-web/test/js/constants.es.js
@@ -24,6 +24,7 @@ const createItems = (size) => {
 					type: 'standalone',
 				},
 			],
+			dataDefinitionId: '123',
 			dataDefinitionName: 'Object',
 			dateCreated: '2020-03-26T11:26:54.262Z',
 			dateModified: '2020-03-26T11:26:54.262Z',

--- a/modules/apps/app-builder/app-builder-web/test/js/pages/apps/__snapshots__/ListApps.es.js.snap
+++ b/modules/apps/app-builder/app-builder-web/test/js/pages/apps/__snapshots__/ListApps.es.js.snap
@@ -234,7 +234,7 @@ exports[`ListApps renders 1`] = `
                   class="table-list-title"
                 >
                   <a
-                    href="#/custom-object/123/apps/1"
+                    href="#/custom-object/123/apps/1?backUrl=/"
                   >
                     Item 1
                   </a>

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.service.permission.LayoutSetPrototypePermission
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -396,14 +397,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 	protected void addTeamRoles(long userId, Group group, Set<Long> roleIds)
 		throws Exception {
 
-		int count = TeamLocalServiceUtil.getGroupTeamsCount(group.getGroupId());
+		long groupId = GroupThreadLocal.getGroupId();
+
+		int count = TeamLocalServiceUtil.getGroupTeamsCount(groupId);
 
 		if (count == 0) {
 			return;
 		}
 
 		List<Role> roles = RoleLocalServiceUtil.getUserTeamRoles(
-			userId, group.getGroupId());
+			userId, groupId);
 
 		for (Role role : roles) {
 			roleIds.add(role.getRoleId());

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -445,7 +445,7 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		}
 
 		long[] roleIds = PermissionCacheUtil.getUserGroupRoleIds(
-			userId, groupId);
+			userId, GetterUtil.getLong(GroupThreadLocal.getGroupId(), groupId));
 
 		if (roleIds != null) {
 			return roleIds;
@@ -568,12 +568,17 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			Arrays.sort(roleIds);
 
-			PermissionCacheUtil.putUserGroupRoleIds(userId, groupId, roleIds);
+			PermissionCacheUtil.putUserGroupRoleIds(
+				userId,
+				GetterUtil.getLong(GroupThreadLocal.getGroupId(), groupId),
+				roleIds);
 
 			return roleIds;
 		}
 		catch (Exception exception) {
-			PermissionCacheUtil.removeUserGroupRoleIds(userId, groupId);
+			PermissionCacheUtil.removeUserGroupRoleIds(
+				userId,
+				GetterUtil.getLong(GroupThreadLocal.getGroupId(), groupId));
 
 			throw exception;
 		}

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -394,10 +394,8 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		}
 	}
 
-	protected void addTeamRoles(long userId, Group group, Set<Long> roleIds)
+	protected void addTeamRoles(long userId, long groupId, Set<Long> roleIds)
 		throws Exception {
-
-		long groupId = GroupThreadLocal.getGroupId();
 
 		int count = TeamLocalServiceUtil.getGroupTeamsCount(groupId);
 
@@ -552,7 +550,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					 userBag.hasUserOrgGroup(group)) ||
 					(group.isSite() && userBag.hasUserGroup(group))) {
 
-					addTeamRoles(userId, group, roleIdsSet);
+					addTeamRoles(
+						userId,
+						GetterUtil.getLong(
+							GroupThreadLocal.getGroupId(), groupId),
+						roleIdsSet);
 				}
 			}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 
 import java.util.Map;
 import java.util.Objects;
@@ -110,12 +111,21 @@ public class StagingPermissionChecker implements PermissionChecker {
 			primKey = liveGroup.getGroupId();
 		}
 
-		if (_isStagingFolder(name, actionId)) {
-			return true;
-		}
+		long previousGroupId = GroupThreadLocal.getGroupId();
 
-		return _permissionChecker.hasPermission(
-			liveGroup, name, primKey, actionId);
+		GroupThreadLocal.setGroupId(group.getGroupId());
+
+		try {
+			if (_isStagingFolder(name, actionId)) {
+				return true;
+			}
+
+			return _permissionChecker.hasPermission(
+				liveGroup, name, primKey, actionId);
+		}
+		finally {
+			GroupThreadLocal.setGroupId(previousGroupId);
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
@@ -113,7 +113,9 @@ public class StagingPermissionChecker implements PermissionChecker {
 
 		long previousGroupId = GroupThreadLocal.getGroupId();
 
-		GroupThreadLocal.setGroupId(group.getGroupId());
+		if (group != null) {
+			GroupThreadLocal.setGroupId(group.getGroupId());
+		}
 
 		try {
 			if (_isStagingFolder(name, actionId)) {

--- a/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
@@ -105,6 +105,10 @@ public class StagingPermissionChecker implements PermissionChecker {
 	public boolean hasPermission(
 		Group group, String name, long primKey, String actionId) {
 
+		if (_isStagingFolder(name, actionId)) {
+			return true;
+		}
+
 		Group liveGroup = StagingUtil.getLiveGroup(group);
 
 		if ((liveGroup != group) && (primKey == group.getGroupId())) {
@@ -118,10 +122,6 @@ public class StagingPermissionChecker implements PermissionChecker {
 		}
 
 		try {
-			if (_isStagingFolder(name, actionId)) {
-				return true;
-			}
-
 			return _permissionChecker.hasPermission(
 				liveGroup, name, primKey, actionId);
 		}


### PR DESCRIPTION
Hi @csierra,

When we check the permissions for an object we always use the live group [see this](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java#L107). This works when Staging is not enabled and also in Staging when no teams are created since, for the rest of permission entities, roles and memberships are a mirror of Live (they only exist in the Live environment). However, teams are a unique case, this entity belongs to the site and we replicate their roles and memberships in both groups, Staging and Live. For that reason, we always need the current groupId when we check the permissions and get the roles for team.

This pull solves this use case but we would like you to validate it as Security Kaiser.

Muchas gracias!

PS: see [PTR-1766](https://issues.liferay.com/browse/PTR-1766) to get more information.

Tests passed here: https://github.com/achaparro/liferay-portal/pull/615

cc/ @samziemer