### PR TITLE
LPS-116147 MFA Configuration should be visible only at Instance Level

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/java/com/liferay/multi/factor/authentication/email/otp/web/internal/configuration/admin/display/MFAEmailOTPConfigurationVisibilityController.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/java/com/liferay/multi/factor/authentication/email/otp/web/internal/configuration/admin/display/MFAEmailOTPConfigurationVisibilityController.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.multi.factor.authentication.email.otp.web.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Marta Medio
+ */
+@Component(
+	immediate = true,
+	property = "configuration.pid=com.liferay.multi.factor.authentication.email.otp.configuration.MFAEmailOTPConfiguration",
+	service = ConfigurationVisibilityController.class
+)
+public class MFAEmailOTPConfigurationVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		if (ExtendedObjectClassDefinition.Scope.COMPANY == scope) {
+			return true;
+		}
+
+		return false;
+	}
+
+}


### PR DESCRIPTION
Hey @csierra 

As I mentioned, I found this case: [LPS-116147](https://issues.liferay.com/browse/LPS-116147) 

I don't think we can use the logic that already exists in [_MFAConfigurationVisibilityController_](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/configuration/admin/display/MFAConfigurationVisibilityController.java) because in this case it is not necessary for MFA to be enabled to show the entry at _Instance Settings_ level; so I had to create a specific Controller for this configuration which is part of the API.
