### PR TITLE
[TECHNICAL-SUPPORT] LPS-88600 Merge permissions during import

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java
@@ -22,7 +22,9 @@ import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,6 +35,24 @@ import java.util.Set;
 public class ExportImportPermissionUtil {
 
 	public static final String ROLE_TEAM_PREFIX = "ROLE_TEAM_,*";
+
+	public static void deleteResourcePermissions(
+			long companyId, String resourceName, String resourcePrimKey,
+			Collection<Long> roleIds)
+		throws PortalException {
+
+		for (long roleId : roleIds) {
+			ResourcePermission resourcePermission =
+				ResourcePermissionLocalServiceUtil.fetchResourcePermission(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					resourcePrimKey, roleId);
+
+			if (resourcePermission != null) {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermission(
+					resourcePermission.getResourcePermissionId());
+			}
+		}
+	}
 
 	public static Map<Long, Set<String>> getRoleIdsToActionIds(
 		long companyId, String resourceName, long resourcePK) {
@@ -101,9 +121,6 @@ public class ExportImportPermissionUtil {
 
 				mergedRoleIdsToActionIds.put(roleId, actionIds);
 			}
-			else {
-				mergedRoleIdsToActionIds.put(roleId, new String[0]);
-			}
 		}
 
 		mergedRoleIdsToActionIds.putAll(importedRoleIdsToActionIds);
@@ -131,17 +148,24 @@ public class ExportImportPermissionUtil {
 				companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
 				resourcePK);
 
-		Map<Long, String[]> mergedRoleIdsToActionIds = new HashMap<>(
-			roleIdsToActionIds);
+		Set<Long> roleIdsToDelete = new HashSet<>();
 
 		for (ResourcePermission resourcePermission : resourcePermissions) {
-			mergedRoleIdsToActionIds.putIfAbsent(
-				resourcePermission.getRoleId(), new String[0]);
+			if (!roleIdsToActionIds.containsKey(
+					resourcePermission.getRoleId())) {
+
+				roleIdsToDelete.add(resourcePermission.getRoleId());
+			}
+		}
+
+		if (!roleIdsToDelete.isEmpty()) {
+			deleteResourcePermissions(
+				companyId, resourceName, resourcePK, roleIdsToDelete);
 		}
 
 		ResourcePermissionLocalServiceUtil.setResourcePermissions(
 			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
-			resourcePK, mergedRoleIdsToActionIds);
+			resourcePK, roleIdsToActionIds);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Hi @csierra .

I'm fixing [LPS-88600](https://issues.liferay.com/browse/LPS-88600), since it's a required for backporting [LPS-83659](https://issues.liferay.com/browse/LPS-83659) to 7.0.x. However, LPS-88600 is also reproducible in master.

The issue is quite complex. Let me explain the details:
* Viewing the portlet permissions on the portal has actually a side-effect: even without saving, just opening the permissions window updates the portlet permissions in the DB. It creates ResourcePermission records specific to the portlet.
* When resetting the page changes, a site template propagation is executed: exporting the template, importing it, overwriting the site.
* In this scenario, the portlet in the template has no specific permission records, so an empty `<permissions/>` tag is sent in the LAR file (this is correct).
* The old version of the permission import deleted all permissions ([ExportImportPermissionUtil.java#L128-L130](https://github.com/liferay/liferay-portal/blob/d3f6533ca5d562725651f55b8f7e4ab7f852150d/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java#L128-L130)) and it worked correctly: removing all portlet-specific ResourcePermission records allows it to use the default ones. One problem with this is performance: even when no permissions changed, it deletes and recreates all of them, for every single portlet in the site.
* The new version ([ExportImportPermissionUtil.java](https://github.com/liferay/liferay-portal/blob/c090845cbddd20efc0b42dde04dcf87b2f2a18ab/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java#L129-L140)) did not delete these permissions, but compared them to the imported ones (which was empty). So if the portlet had any specific permission (e.g. someone opened the permissions window once), it updated all of them, role-by-role, with 0 actionIds, effectively removing all permissions specific to the portlet.
* My proposed solution is to combine these two. There's an extra information in the LAR file that we can use: if the template source explicitly removes all permissions from a role, it sends a `<role>` tag, with no `<action>` tags inside. And when there's no role related records, the `<role>` tag is simply omitted. Basically, the concept is this: try replicate the portlet permissions found in the LAR file into the actual environment. Delete the records that are not defined, update the ones that are different.

I've checked the cases of two other LPSs based on this comment: https://github.com/topolik/liferay-portal/pull/843#issuecomment-650206941
* [LPS-83659](https://issues.liferay.com/browse/LPS-83659) - Worked correctly
* [LPS-76213](https://issues.liferay.com/browse/LPS-76213) - Could not reproduce anymore, there's no option to select permissions for "Copy from Live", not even with Asset Publisher portlet.

Please review my changes.

Thanks,
Vendel